### PR TITLE
Refactor: Centralized job fetching with shared parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.vscode
 # C extensions
 *.so
 

--- a/Scripts/__init__.py
+++ b/Scripts/__init__.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Add parent directory to the path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/Scripts/careerjet.py
+++ b/Scripts/careerjet.py
@@ -1,81 +1,18 @@
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
-
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def careerjet():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
-
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
-    # Prepare the base of the RSS feed
+def careerjet(job_data_list):
     rss_feed = '''<?xml version="1.0" encoding="UTF-8"?>
 <jobs>'''
 
-    # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
-        logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
-
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
-                    rss_feed += f'''
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
+        rss_feed += f'''
             <job> 
               <id><![CDATA[{data.get('identifier', {}).get('value', 'undisclosed')}]]></id>
               <title><![CDATA[{data.get('title', 'undisclosed')}]]></title>
@@ -94,30 +31,17 @@ def careerjet():
               <application_email><![CDATA[info@recruityard.com]]></application_email>
               <apply_url><![CDATA[{job_url}?id={data.get('identifier', {}).get('value', 'undisclosed')}&utm_source=CAREERJET]]></apply_url>
             </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
 
-    # Close the RSS feed
     rss_feed += '''
 </jobs>'''
 
-    # Save the feed to a file
     try:
         with open('careerjet.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated careerjet.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated careerjet.xml")
     except IOError as e:
         logging.error("Failed to write careerjet.xml: %s", e)
 
 if __name__ == "__main__":
-    careerjet()
+    job_data_list = fetch_all_jobs()
+    careerjet(job_data_list)

--- a/Scripts/jobrapido.py
+++ b/Scripts/jobrapido.py
@@ -1,82 +1,20 @@
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
-
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def jobrapido():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
-
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
+def jobrapido(job_data_list):
     # Prepare the base of the RSS feed
     rss_feed = '''<?xml version="1.0" encoding="UTF-8"?>
 <source>
 <jobs>'''
 
-    # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
-
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
-                    rss_feed += f'''
+        rss_feed += f'''
             <job>
               <title><![CDATA[{data.get('title', 'undisclosed')}]]></title>
               <location><![CDATA[{data.get('jobLocation', {}).get('address', {}).get('addressLocality', 'undisclosed')}]]></location>
@@ -94,20 +32,7 @@ def jobrapido():
               <salary><![CDATA[{data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')}]]></salary>
               <jobtype><![CDATA[{data.get('employmentType', 'undisclosed')}]]></jobtype>     
             </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
-
-    # Close the RSS feed
+                
     rss_feed += '''
 </jobs>
 </source>'''
@@ -116,9 +41,10 @@ def jobrapido():
     try:
         with open('jobrapido.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated jobrapido.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated jobrapido.xml")
     except IOError as e:
         logging.error("Failed to write jobrapido.xml: %s", e)
 
 if __name__ == "__main__":
-    jobrapido()
+    job_data_list = fetch_all_jobs()
+    jobrapido(job_data_list)

--- a/Scripts/jobsora.py
+++ b/Scripts/jobsora.py
@@ -1,81 +1,20 @@
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
-
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def jobsora():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
-
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
+def jobsora(job_data_list):
     # Prepare the base of the RSS feed
     rss_feed = '''<?xml version="1.0" encoding="UTF-8"?>
 <jobs>'''
 
     # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
-
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
-                    rss_feed += f'''
+        rss_feed += f'''
             <job id="{data.get('identifier', {}).get('value', 'undisclosed')}">
               <link><![CDATA[{job_url}]]></link>  
               <name><![CDATA[{data.get('title', 'undisclosed')}]]></name>
@@ -92,19 +31,7 @@ def jobsora():
               <expire>{data.get('validThrough', 'undisclosed')}</expire>
               <jobtype><![CDATA[{data.get('employmentType', 'undisclosed')}]]></jobtype>
             </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
-
+        
     # Close the RSS feed
     rss_feed += '''
 </jobs>'''
@@ -113,9 +40,10 @@ def jobsora():
     try:
         with open('jobsora.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated jobsora.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated jobsora.xml")
     except IOError as e:
         logging.error("Failed to write jobsora.xml: %s", e)
 
 if __name__ == "__main__":
-    jobsora()
+    job_data_list = fetch_all_jobs()
+    jobsora(job_data_list)

--- a/Scripts/jooble.py
+++ b/Scripts/jooble.py
@@ -1,49 +1,14 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import datetime
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
 
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def jooble():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
+def jooble(job_data_list):
 
     # Employment type mapping
     employment_type_map = {
@@ -57,73 +22,39 @@ def jooble():
         'OTHER': 'Freelance'
     }
 
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
     # Prepare the base of the RSS feed
     rss_feed = '''<?xml version="1.0" encoding="UTF-8"?>
 <jobs>'''
 
     # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
 
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
+        # Map employment type
+        raw_employment_type = data.get('employmentType', 'undisclosed')
+            
+        # If employmentType is a list, take the first value; otherwise, use as-is
+        if isinstance(raw_employment_type, list):
+            raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
+        employment_type = employment_type_map.get(raw_employment_type, 'Freelance') if raw_employment_type != 'undisclosed' else 'undisclosed'
 
-                    # Map employment type
-                    raw_employment_type = data.get('employmentType', 'undisclosed')
-                    # If employmentType is a list, take the first value; otherwise, use as-is
-                    if isinstance(raw_employment_type, list):
-                        raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
-                    employment_type = employment_type_map.get(raw_employment_type, 'Freelance') if raw_employment_type != 'undisclosed' else 'undisclosed'
-
-                    rss_feed += f'''
-            <job id="{data.get('identifier', {}).get('value', 'undisclosed')}">
-              <link><![CDATA[{job_url}]]></link>  
-              <name><![CDATA[{data.get('title', 'undisclosed')}]]></name>
-              <region><![CDATA[{data.get('jobLocation', {}).get('address', {}).get('addressRegion', 'undisclosed')}]]></region>
-              <country><![CDATA[{data.get('jobLocation', {}).get('address', {}).get('addressCountry', 'undisclosed')}]]></country>
-              <salary><![CDATA[{data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')}]]></salary>
-              <description><![CDATA[{data.get('description', 'undisclosed')}]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>{data.get('datePosted', 'undisclosed')}</pubdate>
-              <updated>{datetime.datetime.now().isoformat()}</updated>
-              <expire>{data.get('validThrough', 'undisclosed')}</expire>
-              <jobtype>{employment_type}</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
+        rss_feed += f'''
+        <job id="{data.get('identifier', {}).get('value', 'undisclosed')}">
+            <link><![CDATA[{job_url}]]></link>  
+            <name><![CDATA[{data.get('title', 'undisclosed')}]]></name>
+            <region><![CDATA[{data.get('jobLocation', {}).get('address', {}).get('addressRegion', 'undisclosed')}]]></region>
+            <country><![CDATA[{data.get('jobLocation', {}).get('address', {}).get('addressCountry', 'undisclosed')}]]></country>
+            <salary><![CDATA[{data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')}]]></salary>
+            <description><![CDATA[{data.get('description', 'undisclosed')}]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>{data.get('datePosted', 'undisclosed')}</pubdate>
+            <updated>{datetime.datetime.now().isoformat()}</updated>
+            <expire>{data.get('validThrough', 'undisclosed')}</expire>
+            <jobtype>{employment_type}</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>'''
 
     # Close the RSS feed
     rss_feed += '''
@@ -133,9 +64,10 @@ def jooble():
     try:
         with open('jooble.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated jooble.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated jooble.xml")
     except IOError as e:
         logging.error("Failed to write jooble.xml: %s", e)
 
 if __name__ == "__main__":
-    jooble()
+    job_data_list = fetch_all_jobs()
+    jooble(job_data_list)

--- a/Scripts/jora.py
+++ b/Scripts/jora.py
@@ -1,50 +1,14 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import datetime
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
 
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def jora():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
-
+def jora(job_data_list):
     # Employment type mapping
     employment_type_map = {
         'FULL_TIME': 'Full time',
@@ -57,73 +21,50 @@ def jora():
         'OTHER': 'Freelance'
     }
 
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
     # Prepare the base of the RSS feed
     rss_feed = f'''<?xml version="1.0" encoding="UTF-8"?>
 <source>
     <publisher>Recruityard</publisher>
     <lastBuildDate>{datetime.datetime.now().isoformat()}</lastBuildDate>'''
 
-    # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
 
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
+        # Extract salary value
+        salary_value = data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')
+        min_salary = 'undisclosed'
+        max_salary = 'undisclosed'
 
-                    # Extract salary value
-                    salary_value = data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')
-                    min_salary = 'undisclosed'
-                    max_salary = 'undisclosed'
+        # Process salary if it's a string
+        if isinstance(salary_value, str):
+            # Handle range format like "1050 - 1300"
+            if '-' in salary_value:
+                salary_parts = [part.strip() for part in salary_value.split('-')]
+                if len(salary_parts) == 2:
+                    # Check if both parts are valid numbers
+                    if (salary_parts[0].replace('.', '').isdigit() and 
+                        salary_parts[1].replace('.', '').isdigit()):
+                        min_salary = salary_parts[0]
+                        max_salary = salary_parts[1]
+            # Handle single value
+            elif salary_value.replace('.', '').isdigit():
+                min_salary = salary_value
+                max_salary = salary_value
+        elif isinstance(salary_value, (int, float)):
+            # Handle numeric values
+            min_salary = str(salary_value)
+            max_salary = str(salary_value)
 
-                    # Process salary if it's a string
-                    if isinstance(salary_value, str):
-                        # Handle range format like "1050 - 1300"
-                        if '-' in salary_value:
-                            salary_parts = [part.strip() for part in salary_value.split('-')]
-                            if len(salary_parts) == 2:
-                                # Check if both parts are valid numbers
-                                if (salary_parts[0].replace('.', '').isdigit() and 
-                                    salary_parts[1].replace('.', '').isdigit()):
-                                    min_salary = salary_parts[0]
-                                    max_salary = salary_parts[1]
-                        # Handle single value
-                        elif salary_value.replace('.', '').isdigit():
-                            min_salary = salary_value
-                            max_salary = salary_value
-                    elif isinstance(salary_value, (int, float)):
-                        # Handle numeric values
-                        min_salary = str(salary_value)
-                        max_salary = str(salary_value)
+        # Map employment type
+        raw_employment_type = data.get('employmentType', 'undisclosed')
+        # If employmentType is a list, take the first value; otherwise, use as-is
+        if isinstance(raw_employment_type, list):
+            raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
+        employment_type = employment_type_map.get(raw_employment_type, 'Freelance') if raw_employment_type != 'undisclosed' else 'undisclosed'
 
-                    # Map employment type
-                    raw_employment_type = data.get('employmentType', 'undisclosed')
-                    # If employmentType is a list, take the first value; otherwise, use as-is
-                    if isinstance(raw_employment_type, list):
-                        raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
-                    employment_type = employment_type_map.get(raw_employment_type, 'Freelance') if raw_employment_type != 'undisclosed' else 'undisclosed'
-
-                    rss_feed += f'''
+        rss_feed += f'''
             <job>
               <title><![CDATA[{data.get('title', 'undisclosed')}]]></title>
               <id><![CDATA[{data.get('identifier', {}).get('value', 'undisclosed')}]]></id>
@@ -144,18 +85,6 @@ def jora():
               <jobtype><![CDATA[{employment_type}]]></jobtype>
               <url><![CDATA[{job_url}]]></url>
             </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
 
     # Close the RSS feed
     rss_feed += '''
@@ -165,9 +94,10 @@ def jora():
     try:
         with open('jora.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated jora.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated jora.xml")
     except IOError as e:
         logging.error("Failed to write jora.xml: %s", e)
 
 if __name__ == "__main__":
-    jora()
+    job_data_list = fetch_all_jobs()
+    jora(job_data_list)

--- a/Scripts/rss.py
+++ b/Scripts/rss.py
@@ -1,102 +1,31 @@
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import logging
-import time
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
-
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def rss():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
-
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
+def rss(job_data_list):
     # Prepare the base of the RSS feed
     rss_feed = '''<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+    <rss version="2.0">
     <channel>
         <title>Recruityard</title>
         <link>https://www.recruityard.com</link>
         <description>Recruityard - Current Job Openings</description>'''
 
     # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
 
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
-                    rss_feed += f'''  
+        rss_feed += f'''  
         <item>
             <title><![CDATA[{data.get('title', 'undisclosed')}]]></title>
             <link><![CDATA[{job_url}]]></link>  
             <description><![CDATA[{data.get('description', 'undisclosed')}]]></description>
         </item>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
 
     # Close the RSS feed
     rss_feed += '''
@@ -107,9 +36,10 @@ def rss():
     try:
         with open('rss.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated rss.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated rss.xml")
     except IOError as e:
         logging.error("Failed to write rss.xml: %s", e)
 
 if __name__ == "__main__":
-    rss()
+    job_data_list = fetch_all_jobs()
+    rss(job_data_list)

--- a/Scripts/talentcom.py
+++ b/Scripts/talentcom.py
@@ -1,49 +1,13 @@
-import datetime
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-from bs4 import BeautifulSoup
-import json
-import html
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import logging
-import time
+import datetime
+from Utils.job_fetcher import fetch_all_jobs
 
-# Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Shared session setup
-def create_resilient_session():
-    session = requests.Session()
-    retries = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[500, 502, 503, 504],
-        connect=3,  # Retry on connection errors
-        read=3,    # Retry on read errors
-        allowed_methods=["GET"]
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    session.headers.update({
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    })
-    return session
-
-def fetch_url(session, url, timeout=15):
-    try:
-        response = session.get(url, timeout=timeout)
-        response.raise_for_status()
-        logging.info("Successfully fetched %s", url)
-        return response.content
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to fetch %s: %s", url, e)
-        raise
-
-def talentcom():
-    # Base URL for the find-jobs section
-    base_url = 'https://recruityard.com/find-jobs-all/'
-    session = create_resilient_session()
+def talentcom(job_data_list):
 
     # Employment type mapping
     employment_type_map = {
@@ -57,18 +21,6 @@ def talentcom():
         'OTHER': 'Other'
     }
 
-    # Load the main jobs page to find all job links
-    try:
-        html_content = fetch_url(session, base_url)
-    except requests.exceptions.RequestException as e:
-        logging.error("Failed to load base URL %s: %s", base_url, e)
-        return
-
-    # Parse the HTML with BeautifulSoup to find all job links
-    soup = BeautifulSoup(html_content, 'html.parser')
-    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
-    logging.info("Found %d unique job links", len(job_links))
-
     # Prepare the base of the RSS feed
     rss_feed = f'''<?xml version="1.0" encoding="UTF-8"?>
 <source>
@@ -77,54 +29,43 @@ def talentcom():
     <lastBuildDate>{datetime.datetime.now().isoformat()}</lastBuildDate>'''
 
     # Iterate over each job link, fetch its content, and extract the JSON
-    success_count = 0
-    failure_count = 0
-    for job_link in job_links:
-        job_url = base_url + job_link.split('/')[-1]
+    for data in job_data_list:
+        job_url = data.get('url', 'undisclosed')
         logging.info("Fetching job URL: %s", job_url)
-        try:
-            job_html_content = fetch_url(session, job_url)
-            job_soup = BeautifulSoup(job_html_content, 'html.parser')
-            script_tag = job_soup.find('script', type='application/ld+json')
-
-            if script_tag and script_tag.string:
-                json_content = html.unescape(script_tag.string)
-                try:
-                    data = json.loads(json_content)
 
                     # Extract salary value
-                    salary_value = data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')
-                    min_salary = 'undisclosed'
-                    max_salary = 'undisclosed'
+        salary_value = data.get('baseSalary', {}).get('value', {}).get('value', 'undisclosed')
+        min_salary = 'undisclosed'
+        max_salary = 'undisclosed'
 
-                    # Process salary if it's a string
-                    if isinstance(salary_value, str):
-                        # Handle range format like "1050 - 1300"
-                        if '-' in salary_value:
-                            salary_parts = [part.strip() for part in salary_value.split('-')]
-                            if len(salary_parts) == 2:
-                                # Check if both parts are valid numbers
-                                if (salary_parts[0].replace('.', '').isdigit() and 
-                                    salary_parts[1].replace('.', '').isdigit()):
-                                    min_salary = salary_parts[0]
-                                    max_salary = salary_parts[1]
-                        # Handle single value
-                        elif salary_value.replace('.', '').isdigit():
-                            min_salary = salary_value
-                            max_salary = salary_value
-                    elif isinstance(salary_value, (int, float)):
-                        # Handle numeric values
-                        min_salary = str(salary_value)
-                        max_salary = str(salary_value)
+        # Process salary if it's a string
+        if isinstance(salary_value, str):
+            # Handle range format like "1050 - 1300"
+            if '-' in salary_value:
+                salary_parts = [part.strip() for part in salary_value.split('-')]
+                if len(salary_parts) == 2:
+                    # Check if both parts are valid numbers
+                    if (salary_parts[0].replace('.', '').isdigit() and 
+                        salary_parts[1].replace('.', '').isdigit()):
+                        min_salary = salary_parts[0]
+                        max_salary = salary_parts[1]
+            # Handle single value
+            elif salary_value.replace('.', '').isdigit():
+                min_salary = salary_value
+                max_salary = salary_value
+        elif isinstance(salary_value, (int, float)):
+            # Handle numeric values
+            min_salary = str(salary_value)
+            max_salary = str(salary_value)
 
-                    # Map employment type
-                    raw_employment_type = data.get('employmentType', 'undisclosed')
-                    # If employmentType is a list, take the first value; otherwise, use as-is
-                    if isinstance(raw_employment_type, list):
-                        raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
-                    employment_type = employment_type_map.get(raw_employment_type, 'Other') if raw_employment_type != 'undisclosed' else 'undisclosed'
+        # Map employment type
+        raw_employment_type = data.get('employmentType', 'undisclosed')
+        # If employmentType is a list, take the first value; otherwise, use as-is
+        if isinstance(raw_employment_type, list):
+            raw_employment_type = raw_employment_type[0] if raw_employment_type else 'undisclosed'
+        employment_type = employment_type_map.get(raw_employment_type, 'Other') if raw_employment_type != 'undisclosed' else 'undisclosed'
 
-                    rss_feed += f'''
+        rss_feed += f'''
             <job>
               <title><![CDATA[{data.get('title', 'undisclosed')}]]></title>
               <company><![CDATA[{data.get('hiringOrganization', {}).get('name', 'undisclosed')}]]></company>
@@ -148,18 +89,6 @@ def talentcom():
               <category><![CDATA[{data.get('industry', 'undisclosed')}]]></category>
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>'''
-                    success_count += 1
-                except json.JSONDecodeError as e:
-                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
-                    failure_count += 1
-            else:
-                logging.warning("No JSON-LD script tag found in %s", job_url)
-                failure_count += 1
-        except requests.exceptions.RequestException as e:
-            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
-            failure_count += 1
-            continue
-        time.sleep(1)  # Delay to avoid rate-limiting
 
     # Close the RSS feed
     rss_feed += '''
@@ -169,9 +98,10 @@ def talentcom():
     try:
         with open('talentcom.xml', 'w', encoding='utf-8') as f:
             f.write(rss_feed)
-        logging.info("Generated talentcom.xml: %d jobs processed successfully, %d failed", success_count, failure_count)
+        logging.info("Generated talentcom.xml")
     except IOError as e:
         logging.error("Failed to write talentcom.xml: %s", e)
 
 if __name__ == "__main__":
-    talentcom()
+    job_data_list = fetch_all_jobs()
+    talentcom(job_data_list)

--- a/Utils/job_fetcher.py
+++ b/Utils/job_fetcher.py
@@ -1,0 +1,90 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from bs4 import BeautifulSoup
+import json
+import html
+import logging
+import time
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def create_resilient_session():
+    session = requests.Session()
+    retries = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[500, 502, 503, 504],
+        connect=3,  # Retry on connection errors
+        read=3,    # Retry on read errors
+        allowed_methods=["GET"]
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.headers.update({
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+    })
+    return session
+
+def fetch_url(session, url, timeout=15):
+    try:
+        response = session.get(url, timeout=timeout)
+        response.raise_for_status()
+        logging.info("Successfully fetched %s", url)
+        return response.content
+    except requests.exceptions.RequestException as e:
+        logging.error("Failed to fetch %s: %s", url, e)
+        raise
+
+def fetch_all_jobs(base_url="https://recruityard.com/find-jobs-all/"):
+    session = create_resilient_session()
+    job_data_list = []
+
+    # Load the main jobs page to find all job links
+    try:
+        html_content = fetch_url(session, base_url)
+    except requests.exceptions.RequestException as e:
+        logging.error("Failed to load base URL %s: %s", base_url, e)
+        return
+
+    # Parse the HTML with BeautifulSoup to find all job links
+    soup = BeautifulSoup(html_content, 'html.parser')
+    job_links = list(set([a['href'] for a in soup.find_all('a', href=True) if '/find-jobs-all/' in a['href']]))
+    logging.info("Found %d unique job links", len(job_links))
+
+    # Iterate over each job link, fetch its content, and extract the JSON
+    success_count = 0
+    failure_count = 0
+    for job_link in job_links:
+        job_url = base_url + job_link.split('/')[-1]
+        logging.info("Fetching job URL: %s", job_url)
+        try:
+            job_html_content = fetch_url(session, job_url)
+            job_soup = BeautifulSoup(job_html_content, 'html.parser')
+            script_tag = job_soup.find('script', type='application/ld+json')
+            
+            if script_tag and script_tag.string:
+                json_content = html.unescape(script_tag.string)
+                try:
+                    data = json.loads(json_content)
+                    data['url'] = job_url
+                    job_data_list.append(data)
+                    success_count += 1
+                except json.JSONDecodeError as e:
+                    logging.warning("Error decoding JSON from %s: %s", job_url, e)
+                    continue
+            else:
+                logging.warning("No JSON-LD script tag found in %s", job_url)
+                failure_count += 1
+        except requests.exceptions.RequestException as e:
+            logging.warning("Skipping job %s due to fetch error: %s", job_url, e)
+            failure_count += 1
+            continue
+        time.sleep(1)
+    
+    logging.info("Successfully fetched %d jobs, %d failed", success_count, failure_count)
+    return job_data_list
+
+if __name__ == "__main__":
+    job_data_list = fetch_all_jobs()

--- a/careerjet.xml
+++ b/careerjet.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobs>
             <job> 
-              <id><![CDATA[CC-0506-52]]></id>
-              <title><![CDATA[Sales Advisor with Polish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-21]]></id>
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -11,42 +11,684 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
 <ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Employer requirements:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt?id=CC-0506-21&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-17]]></id>
+              <title><![CDATA[Content Moderation with Finnish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt?id=CC-0506-17&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-16]]></id>
+              <title><![CDATA[Content Moderation with Danish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt?id=CC-0506-16&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-23]]></id>
+              <title><![CDATA[Content Moderation with Bulgarian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt?id=CC-0506-23&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-19]]></id>
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
+              <location>
+                <city><![CDATA[Braga]]></city>
+                <region><![CDATA[Braga]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt?id=CC-0506-19&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-8]]></id>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt?id=CC-0506-8&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-34]]></id>
+              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
               <salary><![CDATA[1059 - 1260]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt?id=CC-0506-52&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt?id=CC-0506-34&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-67]]></id>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr?id=CC-0506-67&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-82]]></id>
+              <title><![CDATA[Content Moderation with Czech]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1068 - 1270]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt?id=CC-0506-82&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-69]]></id>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr?id=CC-0506-69&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-85]]></id>
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1100 - 1400]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt?id=CC-0506-85&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-61]]></id>
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr?id=CC-0506-61&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-71]]></id>
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr?id=CC-0506-71&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-24]]></id>
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt?id=CC-0506-24&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-49]]></id>
+              <title><![CDATA[Customer Support with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
+              <location>
+                <city><![CDATA[Sofia]]></city>
+                <region><![CDATA[Sofia]]></region>
+                <country><![CDATA[BG]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg?id=CC-0506-49&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0506-43]]></id>
@@ -97,9 +739,9 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt?id=CC-0506-43&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-60]]></id>
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-30]]></id>
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -107,10 +749,105 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1400 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt?id=CC-0506-30&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-87]]></id>
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1249]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt?id=CC-0506-87&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-26]]></id>
+              <title><![CDATA[Client Services Officer with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></url>
+              <location>
+                <city><![CDATA[Madrid]]></city>
+                <region><![CDATA[Madrid]]></region>
+                <country><![CDATA[ES]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -122,7 +859,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French</li>
+<li>- Fluency in German</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -140,9 +877,341 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1100 - 1300]]></salary>
+              <salary><![CDATA[1750 - 2000]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt?id=CC-0506-60&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es?id=CC-0506-26&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-57]]></id>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
+              <location>
+                <city><![CDATA[Madrid]]></city>
+                <region><![CDATA[Madrid]]></region>
+                <country><![CDATA[ES]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1750 - 2000]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es?id=CC-0506-57&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-31]]></id>
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt?id=CC-0506-31&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-80]]></id>
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1237]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt?id=CC-0506-80&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-11]]></id>
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt?id=CC-0506-11&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-86]]></id>
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt?id=CC-0506-86&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-35]]></id>
+              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt?id=CC-0506-35&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0528-02]]></id>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt?id=CC-0528-02&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0506-2]]></id>
@@ -194,349 +1263,20 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt?id=CC-0506-2&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-68]]></id>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr?id=CC-0506-68&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-14]]></id>
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt?id=CC-0506-14&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-66]]></id>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr?id=CC-0506-66&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-80]]></id>
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1237]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt?id=CC-0506-80&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-77]]></id>
-              <title><![CDATA[Customer Support with Czech]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
-              <location>
-                <city><![CDATA[Sofia]]></city>
-                <region><![CDATA[Sofia]]></region>
-                <country><![CDATA[BG]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg?id=CC-0506-77&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-16]]></id>
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt?id=CC-0506-16&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-65]]></id>
-              <title><![CDATA[Client Support with Polish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr?id=CC-0506-65&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-57]]></id>
+              <id><![CDATA[CC-0506-59]]></id>
               <title><![CDATA[Client Services Officer with English]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
               <location>
-                <city><![CDATA[Madrid]]></city>
-                <region><![CDATA[Madrid]]></region>
-                <country><![CDATA[ES]]></country>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
               <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -566,14 +1306,59 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1750 - 2000]]></salary>
+              <salary><![CDATA[1100 - 1300]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es?id=CC-0506-57&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt?id=CC-0506-59&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-28]]></id>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-20]]></id>
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt?id=CC-0506-20&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-25]]></id>
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -581,8 +1366,8 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -593,7 +1378,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -613,21 +1398,21 @@
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
               <salary><![CDATA[1050 - 1306]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt?id=CC-0506-28&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt?id=CC-0506-25&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-17]]></id>
-              <title><![CDATA[Content Moderation with Finnish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-6]]></id>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
               <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
                 <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -638,7 +1423,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -656,53 +1441,54 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1350 - 1620]]></salary>
+              <salary><![CDATA[1000 - 1100]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt?id=CC-0506-17&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt?id=CC-0506-6&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-55]]></id>
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+              <id><![CDATA[CC-0506-9]]></id>
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
               <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
                 <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Qualifications:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
-<h3>Training and Development:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1200]]></salary>
+              <salary><![CDATA[1050 - 1306]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt?id=CC-0506-55&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt?id=CC-0506-9&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0506-75]]></id>
@@ -752,9 +1538,9 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg?id=CC-0506-75&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-84]]></id>
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
+              <id><![CDATA[CC-0506-79]]></id>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
               <location>
                 <city><![CDATA[Portugal]]></city>
                 <region><![CDATA[Portugal]]></region>
@@ -762,473 +1548,8 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt?id=CC-0506-84&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-42]]></id>
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt?id=CC-0506-42&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-21]]></id>
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt?id=CC-0506-21&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-44]]></id>
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt?id=CC-0506-44&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-38]]></id>
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt?id=CC-0506-38&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-83]]></id>
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[2450]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt?id=CC-0506-83&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-6]]></id>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt?id=CC-0506-6&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-86]]></id>
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt?id=CC-0506-86&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506]]></id>
-              <title><![CDATA[Beauty Advisor with Dutch]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1050 - 1300]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt?id=CC-0506&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-54]]></id>
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt?id=CC-0506-54&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-69]]></id>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -1241,7 +1562,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Finnish.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1250,7 +1571,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -1259,54 +1580,9 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1300 - 1600]]></salary>
+              <salary><![CDATA[1100 - 1300]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr?id=CC-0506-69&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-4]]></id>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt?id=CC-0506-4&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt?id=CC-0506-79&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0528-04]]></id>
@@ -1356,614 +1632,6 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt?id=CC-0528-04&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-51]]></id>
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt?id=CC-0506-51&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-79]]></id>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt?id=CC-0506-79&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-39]]></id>
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt?id=CC-0506-39&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-59]]></id>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt?id=CC-0506-59&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-61]]></id>
-              <title><![CDATA[Client Support with Italian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr?id=CC-0506-61&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-78]]></id>
-              <title><![CDATA[Customer Support with Slovenian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
-              <location>
-                <city><![CDATA[Sofia]]></city>
-                <region><![CDATA[Sofia]]></region>
-                <country><![CDATA[BG]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg?id=CC-0506-78&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-13]]></id>
-              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1350 ]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt?id=CC-0506-13&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-31]]></id>
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt?id=CC-0506-31&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0527]]></id>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt?id=CC-0527&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-24]]></id>
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt?id=CC-0506-24&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-89]]></id>
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1295]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt?id=CC-0506-89&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-27]]></id>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt?id=CC-0506-27&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-56]]></id>
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt?id=CC-0506-56&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
               <id><![CDATA[CC-0506-70]]></id>
               <title><![CDATA[Client Support with Icelandic - Remote]]></title>
               <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
@@ -2011,244 +1679,9 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr?id=CC-0506-70&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0528-05]]></id>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt?id=CC-0528-05&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-81]]></id>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt?id=CC-0506-81&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-18]]></id>
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt?id=CC-0506-18&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-5]]></id>
-              <title><![CDATA[Beauty Advisor with Italian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1040 - 1259]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt?id=CC-0506-5&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0528-03]]></id>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt?id=CC-0528-03&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-67]]></id>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <id><![CDATA[CC-0506-65]]></id>
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
               <location>
                 <city><![CDATA[Greece]]></city>
                 <region><![CDATA[Greece]]></region>
@@ -2256,7 +1689,7 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -2270,7 +1703,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Norwegian.</li>
+<li>- Fluency in Polish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2288,115 +1721,23 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1300 - 1600]]></salary>
+              <salary><![CDATA[1045 - 1200]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr?id=CC-0506-67&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr?id=CC-0506-65&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-49]]></id>
-              <title><![CDATA[Customer Support with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
+              <id><![CDATA[CC-0506-54]]></id>
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
               <location>
-                <city><![CDATA[Sofia]]></city>
-                <region><![CDATA[Sofia]]></region>
-                <country><![CDATA[BG]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg?id=CC-0506-49&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-10]]></id>
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
                 <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt?id=CC-0506-10&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-53]]></id>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
-              <location>
-                <city><![CDATA[Braga]]></city>
-                <region><![CDATA[Braga]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2420,19 +1761,19 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
+<li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
               <salary><![CDATA[1000 - 1200]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt?id=CC-0506-53&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt?id=CC-0506-54&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-35]]></id>
-              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-15]]></id>
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -2441,7 +1782,7 @@
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2455,7 +1796,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
+<li>- Fluency in Hebrew.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2473,25 +1814,25 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt?id=CC-0506-35&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt?id=CC-0506-15&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-71]]></id>
-              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <id><![CDATA[CC-0506-77]]></id>
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
               <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
+                <city><![CDATA[Sofia]]></city>
+                <region><![CDATA[Sofia]]></region>
+                <country><![CDATA[BG]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -2502,8 +1843,8 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -2511,302 +1852,26 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1045 - 1200]]></salary>
+              <salary><![CDATA[3000 - 5000]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr?id=CC-0506-71&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg?id=CC-0506-77&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-19]]></id>
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
-              <location>
-                <city><![CDATA[Braga]]></city>
-                <region><![CDATA[Braga]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt?id=CC-0506-19&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-62]]></id>
-              <title><![CDATA[Client Support with French - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr?id=CC-0506-62&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-33]]></id>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
-              <location>
-                <city><![CDATA[Greece]]></city>
-                <region><![CDATA[Greece]]></region>
-                <country><![CDATA[GR]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr?id=CC-0506-33&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-25]]></id>
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-28]]></id>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt?id=CC-0506-25&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0528-01]]></id>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt?id=CC-0528-01&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-20]]></id>
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt?id=CC-0506-20&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-7]]></id>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
                 <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
@@ -2841,99 +1906,50 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1150]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt?id=CC-0506-7&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-23]]></id>
-              <title><![CDATA[Content Moderation with Bulgarian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
               <salary><![CDATA[1050 - 1306]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt?id=CC-0506-23&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt?id=CC-0506-28&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0527-74]]></id>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <id><![CDATA[CC-0506-83]]></id>
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
               <location>
-                <city><![CDATA[Guimarães]]></city>
-                <region><![CDATA[Braga]]></region>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
                 <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
 <ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
 </ul>
-<h3>O que procuramos:</h3>
+<h3>Benefícios Adicionais:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
 </ul>
-<h3>O que oferecemos:</h3>
+<h3>Requisitos:</h3>
 <ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1160 - 1600]]></salary>
+              <salary><![CDATA[2450]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt?id=CC-0527-74&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt?id=CC-0506-83&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0506-3]]></id>
@@ -2985,287 +2001,9 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt?id=CC-0506-3&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-82]]></id>
-              <title><![CDATA[Content Moderation with Czech]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt?id=CC-0506-82&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-15]]></id>
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt?id=CC-0506-15&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-12]]></id>
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
-              <location>
-                <city><![CDATA[Porto]]></city>
-                <region><![CDATA[Porto]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt?id=CC-0506-12&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-50]]></id>
-              <title><![CDATA[Customer Support with Dutch]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
-              <location>
-                <city><![CDATA[Sofia]]></city>
-                <region><![CDATA[Sofia]]></region>
-                <country><![CDATA[BG]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg?id=CC-0506-50&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-30]]></id>
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1400 - 1600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt?id=CC-0506-30&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-88]]></id>
-              <title><![CDATA[Customer Support with French - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
-              <location>
-                <city><![CDATA[Bulgaria]]></city>
-                <region><![CDATA[Bulgaria]]></region>
-                <country><![CDATA[BG]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[2600]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg?id=CC-0506-88&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-85]]></id>
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <id><![CDATA[CC-0528-01]]></id>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
               <location>
                 <city><![CDATA[Portugal]]></city>
                 <region><![CDATA[Portugal]]></region>
@@ -3273,7 +2011,7 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -3287,7 +2025,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Turkish.</li>
+<li>- Fluency in Danish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3305,151 +2043,14 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1100 - 1400]]></salary>
+              <salary><![CDATA[1358 - 1620]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt?id=CC-0506-85&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt?id=CC-0528-01&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-11]]></id>
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt?id=CC-0506-11&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-87]]></id>
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
-              <location>
-                <city><![CDATA[Portugal]]></city>
-                <region><![CDATA[Portugal]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1249]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt?id=CC-0506-87&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-9]]></id>
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
-              <location>
-                <city><![CDATA[Lisbon]]></city>
-                <region><![CDATA[Lisbon]]></region>
-                <country><![CDATA[PT]]></country>
-              </location>  
-              <company><![CDATA[Recruityard]]></company>
-              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <contract_type><![CDATA[permanent]]></contract_type>
-              <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt?id=CC-0506-9&utm_source=CAREERJET]]></apply_url>
-            </job>
-            <job> 
-              <id><![CDATA[CC-0506-34]]></id>
-              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-13]]></id>
+              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -3458,7 +2059,7 @@
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3472,7 +2073,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3490,14 +2091,250 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1059 - 1260]]></salary>
+              <salary><![CDATA[1059 - 1350 ]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt?id=CC-0506-34&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt?id=CC-0506-13&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-36]]></id>
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-4]]></id>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1150 - 1250]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt?id=CC-0506-4&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0528-03]]></id>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt?id=CC-0528-03&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-33]]></id>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr?id=CC-0506-33&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-52]]></id>
+              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt?id=CC-0506-52&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-5]]></id>
+              <title><![CDATA[Beauty Advisor with Italian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1040 - 1259]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt?id=CC-0506-5&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-38]]></id>
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -3506,7 +2343,7 @@
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3520,7 +2357,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in French.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3540,55 +2377,103 @@
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
               <salary><![CDATA[1000 - 1260]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt?id=CC-0506-36&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt?id=CC-0506-38&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-26]]></id>
-              <title><![CDATA[Client Services Officer with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></url>
+              <id><![CDATA[CC-0506-51]]></id>
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
               <location>
-                <city><![CDATA[Madrid]]></city>
-                <region><![CDATA[Madrid]]></region>
-                <country><![CDATA[ES]]></country>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
 <ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
 </ul>
-<h3>What You Need:</h3>
+<h3>Employer requirements:</h3>
 <ul>
-<li>- Fluency in German</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
 </ul>
-<h3>What We Offer:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1750 - 2000]]></salary>
+              <salary><![CDATA[1059 - 1260]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es?id=CC-0506-26&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt?id=CC-0506-51&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-84]]></id>
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt?id=CC-0506-84&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
               <id><![CDATA[CC-0506-32]]></id>
@@ -3638,9 +2523,56 @@
               <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr?id=CC-0506-32&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0506-8]]></id>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <id><![CDATA[CC-0506-81]]></id>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt?id=CC-0506-81&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-10]]></id>
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
               <location>
                 <city><![CDATA[Lisbon]]></city>
                 <region><![CDATA[Lisbon]]></region>
@@ -3648,8 +2580,8 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3660,7 +2592,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3678,14 +2610,153 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1050 - 1306]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt?id=CC-0506-8&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt?id=CC-0506-10&utm_source=CAREERJET]]></apply_url>
             </job>
             <job> 
-              <id><![CDATA[CC-0528-02]]></id>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>
+              <id><![CDATA[CC-0506-50]]></id>
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
+              <location>
+                <city><![CDATA[Sofia]]></city>
+                <region><![CDATA[Sofia]]></region>
+                <country><![CDATA[BG]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg?id=CC-0506-50&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-18]]></id>
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt?id=CC-0506-18&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-66]]></id>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr?id=CC-0506-66&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-55]]></id>
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
               <location>
                 <city><![CDATA[Portugal]]></city>
                 <region><![CDATA[Portugal]]></region>
@@ -3693,8 +2764,703 @@
               </location>  
               <company><![CDATA[Recruityard]]></company>
               <company_url><![CDATA[https://www.recruityard.com]]></company_url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt?id=CC-0506-55&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-53]]></id>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+              <location>
+                <city><![CDATA[Braga]]></city>
+                <region><![CDATA[Braga]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt?id=CC-0506-53&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0527-74]]></id>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <location>
+                <city><![CDATA[Guimarães]]></city>
+                <region><![CDATA[Braga]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt?id=CC-0527-74&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-7]]></id>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1150]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt?id=CC-0506-7&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-60]]></id>
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt?id=CC-0506-60&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0527]]></id>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt?id=CC-0527&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-89]]></id>
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1295]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt?id=CC-0506-89&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-12]]></id>
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1250]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt?id=CC-0506-12&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-27]]></id>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1306]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt?id=CC-0506-27&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-42]]></id>
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt?id=CC-0506-42&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-39]]></id>
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt?id=CC-0506-39&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-78]]></id>
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
+              <location>
+                <city><![CDATA[Sofia]]></city>
+                <region><![CDATA[Sofia]]></region>
+                <country><![CDATA[BG]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg?id=CC-0506-78&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506]]></id>
+              <title><![CDATA[Beauty Advisor with Dutch]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
+              <location>
+                <city><![CDATA[Porto]]></city>
+                <region><![CDATA[Porto]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1050 - 1300]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt?id=CC-0506&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-44]]></id>
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt?id=CC-0506-44&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0528-05]]></id>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt?id=CC-0528-05&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-68]]></id>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -3716,7 +3482,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -3725,8 +3491,242 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <contract_type><![CDATA[permanent]]></contract_type>
               <working_hours><![CDATA[FULL_TIME]]></working_hours>
-              <salary><![CDATA[1358 - 1620]]></salary>
+              <salary><![CDATA[1300 - 1600]]></salary>
               <application_email><![CDATA[info@recruityard.com]]></application_email>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt?id=CC-0528-02&utm_source=CAREERJET]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr?id=CC-0506-68&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-88]]></id>
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
+              <location>
+                <city><![CDATA[Bulgaria]]></city>
+                <region><![CDATA[Bulgaria]]></region>
+                <country><![CDATA[BG]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[2600]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg?id=CC-0506-88&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-14]]></id>
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1500]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt?id=CC-0506-14&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-62]]></id>
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
+              <location>
+                <city><![CDATA[Greece]]></city>
+                <region><![CDATA[Greece]]></region>
+                <country><![CDATA[GR]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr?id=CC-0506-62&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-56]]></id>
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
+              <location>
+                <city><![CDATA[Portugal]]></city>
+                <region><![CDATA[Portugal]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt?id=CC-0506-56&utm_source=CAREERJET]]></apply_url>
+            </job>
+            <job> 
+              <id><![CDATA[CC-0506-36]]></id>
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <location>
+                <city><![CDATA[Lisbon]]></city>
+                <region><![CDATA[Lisbon]]></region>
+                <country><![CDATA[PT]]></country>
+              </location>  
+              <company><![CDATA[Recruityard]]></company>
+              <company_url><![CDATA[https://www.recruityard.com]]></company_url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <contract_type><![CDATA[permanent]]></contract_type>
+              <working_hours><![CDATA[FULL_TIME]]></working_hours>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <application_email><![CDATA[info@recruityard.com]]></application_email>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt?id=CC-0506-36&utm_source=CAREERJET]]></apply_url>
             </job>
 </jobs>

--- a/feed.xml
+++ b/feed.xml
@@ -3,10 +3,10 @@
     <publisher>Recruityard</publisher>
     <publisherurl>https://www.recruityard.com</publisherurl>
             <job>
-              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-52]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-21]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
@@ -14,438 +14,8 @@
               <country><![CDATA[PT]]></country>
               <remote><![CDATA[ no ]]></remote>
               <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Czech]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-43]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-60]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with German]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-2]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in German.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1084 - 1448]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-68]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-14]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-66]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-80]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1237]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Czech]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-77]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-16]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -456,7 +26,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -475,146 +45,6 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
               <salary><![CDATA[1350 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Polish - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-65]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-57]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Madrid]]></location>
-              <city><![CDATA[Madrid]]></city>
-              <state><![CDATA[Madrid]]></state>
-              <country><![CDATA[ES]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[28001]]></postalcode>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1750 - 2000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-28]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1050 - 1306]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
@@ -663,149 +93,10 @@
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <title><![CDATA[Content Moderation with Danish]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-55]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovak]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-75]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-84]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-42]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-16]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
@@ -813,2009 +104,8 @@
               <country><![CDATA[PT]]></country>
               <remote><![CDATA[ no ]]></remote>
               <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-21]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-44]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-38]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-83]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Healthcare]]></category>
-              <salary><![CDATA[2450]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-6]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-86]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Dutch]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1050 - 1300]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-54]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-69]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-4]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0528-04]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-51]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-79]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-39]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-59]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Italian - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-61]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovenian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-78]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-13]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1350 ]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-31]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0527]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-24]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-89]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1295]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-27]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-56]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-70]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0528-05]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-81]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-18]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Italian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-5]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1040 - 1259]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0528-03]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-67]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with German]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-49]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-10]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-53]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Braga]]></location>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4700]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-35]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-71]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-19]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Braga]]></location>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4700]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with French - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-62]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-33]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-25]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0528-01]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
               <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-20]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-7]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2826,7 +116,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -2844,7 +134,7 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1150]]></salary>
+              <salary><![CDATA[1350 - 1620]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
@@ -2893,19 +183,19 @@
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0527-74]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-19]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Guimarães]]></location>
-              <city><![CDATA[Guimarães]]></city>
+              <location><![CDATA[Braga]]></location>
+              <city><![CDATA[Braga]]></city>
               <state><![CDATA[Braga]]></state>
               <country><![CDATA[PT]]></country>
               <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4800]]></postalcode>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <postalcode><![CDATA[4700]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2916,7 +206,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
+<li>- Fluência em Alemão;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -2929,68 +219,19 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Local de trabalho - Braga</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1160 - 1600]]></salary>
+              <salary><![CDATA[1000 - 1200]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Beauty Advisor with Greek]]></title>
+              <title><![CDATA[Content Moderation with German]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-3]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Greek.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1059 - 1259]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Czech]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-82]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-8]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
@@ -2998,8 +239,8 @@
               <country><![CDATA[PT]]></country>
               <remote><![CDATA[ no ]]></remote>
               <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3010,424 +251,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-15]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-12]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Dutch]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-50]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-30]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1400 - 1600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with French - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-88]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Bulgaria]]></location>
-              <city><![CDATA[Bulgaria]]></city>
-              <state><![CDATA[Bulgaria]]></state>
-              <country><![CDATA[BG]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[2600]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-85]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1100 - 1400]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-11]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-87]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-              <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1249]]></salary>
-              <email><![CDATA[info@recruityard.com]]></email>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-9]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
-              <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <remote><![CDATA[ no ]]></remote>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3497,10 +321,430 @@
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-36]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-67]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Czech]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-82]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1068 - 1270]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-69]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-85]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1100 - 1400]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-61]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-71]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-24]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with German]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-49]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Czech]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-43]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-30]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
@@ -3509,7 +753,7 @@
               <remote><![CDATA[ no ]]></remote>
               <postalcode><![CDATA[1000]]></postalcode>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3523,7 +767,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in Turkish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3541,7 +785,54 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1000 - 1260]]></salary>
+              <salary><![CDATA[1400 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-87]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1249]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
@@ -3593,32 +884,81 @@
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
+              <title><![CDATA[Client Services Officer with English]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-32]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
+              <referencenumber><![CDATA[CC-0506-57]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
               <company><![CDATA[Recruityard]]></company>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <remote><![CDATA[ yes ]]></remote>
-              <postalcode><![CDATA[]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+              <location><![CDATA[Madrid]]></location>
+              <city><![CDATA[Madrid]]></city>
+              <state><![CDATA[Madrid]]></state>
+              <country><![CDATA[ES]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[28001]]></postalcode>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German.</li>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1750 - 2000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-31]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3627,23 +967,23 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1300 - 1600]]></salary>
+              <salary><![CDATA[1059 - 1260]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with German]]></title>
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
               <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
-              <referencenumber><![CDATA[CC-0506-8]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-80]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
               <company><![CDATA[Recruityard]]></company>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
@@ -3651,8 +991,56 @@
               <country><![CDATA[PT]]></country>
               <remote><![CDATA[ no ]]></remote>
               <postalcode><![CDATA[1000]]></postalcode>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1237]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-11]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3663,7 +1051,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3681,7 +1069,103 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
-              <salary><![CDATA[1050 - 1306]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-86]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-35]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
             <job>
@@ -3729,6 +1213,2522 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
               <category><![CDATA[Customer Service]]></category>
               <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with German]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-2]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in German.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1084 - 1448]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-59]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-20]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-25]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-6]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1100]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-9]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovak]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-75]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-79]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0528-04]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-70]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-65]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-54]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-15]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hebrew.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-77]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-28]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-83]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
+<ul>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+</ul>
+<h3>Benefícios Adicionais:</h3>
+<ul>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+</ul>
+<h3>Requisitos:</h3>
+<ul>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Healthcare]]></category>
+              <salary><![CDATA[2450]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Greek]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-3]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Greek.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1259]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0528-01]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-13]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1350 ]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-4]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1150 - 1250]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0528-03]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-33]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-52]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Italian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-5]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1040 - 1259]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-38]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-51]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-84]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-32]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-81]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-10]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-50]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-18]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-66]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-55]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-53]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Braga]]></location>
+              <city><![CDATA[Braga]]></city>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4700]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0527-74]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Guimarães]]></location>
+              <city><![CDATA[Guimarães]]></city>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4800]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-7]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1150]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-60]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0527]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-89]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1295]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-12]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1250]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-27]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1306]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-42]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-39]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-78]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Dutch]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1050 - 1300]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-44]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <date><![CDATA[2025-05-28T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0528-05]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-68]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-88]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Bulgaria]]></location>
+              <city><![CDATA[Bulgaria]]></city>
+              <state><![CDATA[Bulgaria]]></state>
+              <country><![CDATA[BG]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[2600]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-14]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1500]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-62]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-56]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ yes ]]></remote>
+              <postalcode><![CDATA[]]></postalcode>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <email><![CDATA[info@recruityard.com]]></email>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <date><![CDATA[2025-05-27T00:00:00.000Z]]></date>
+              <referencenumber><![CDATA[CC-0506-36]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <company><![CDATA[Recruityard]]></company>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <remote><![CDATA[ no ]]></remote>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+              <category><![CDATA[Customer Service]]></category>
+              <salary><![CDATA[1000 - 1260]]></salary>
               <email><![CDATA[info@recruityard.com]]></email>
             </job>
 </source>

--- a/jobatus.xml
+++ b/jobatus.xml
@@ -1,124 +1,574 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobatus>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
 <ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>What You Need:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Sales Advisor with Polish]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Finnish]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Danish]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Bulgarian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
+              <content><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <city><![CDATA[Braga]]></city>
+              <region><![CDATA[Braga]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with German]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
               <salary><![CDATA[1059 - 1260]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Czech]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1068 - 1270]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1100 - 1400]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>  
+              <title><![CDATA[Customer Support with German]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <city><![CDATA[Sofia]]></city>
+              <region><![CDATA[Sofia]]></region>
             </ad>
             <ad>
               <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>  
@@ -161,9 +611,52 @@
               <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>  
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1400 - 1600]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -174,15 +667,16 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -191,17 +685,17 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <city><![CDATA[Porto]]></city>
-              <region><![CDATA[Porto]]></region>
+              <salary><![CDATA[1249]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>  
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <content><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></url>  
+              <title><![CDATA[Client Services Officer with German]]></title>
+              <content><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -213,7 +707,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French</li>
+<li>- Fluency in German</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -231,7 +725,204 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1100 - 1300]]></salary>
+              <salary><![CDATA[1750 - 2000]]></salary>
+              <city><![CDATA[Madrid]]></city>
+              <region><![CDATA[Madrid]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>  
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <content><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1750 - 2000]]></salary>
+              <city><![CDATA[Madrid]]></city>
+              <region><![CDATA[Madrid]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1237]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1358 - 1620]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
             </ad>
@@ -274,6 +965,45 @@
               <salary><![CDATA[1059 - 1260]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
               <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>  
@@ -357,10 +1087,390 @@
               <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <content><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>  
+              <title><![CDATA[Content Moderation with French]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1100]]></salary>
+              <city><![CDATA[Porto]]></city>
+              <region><![CDATA[Porto]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>  
+              <title><![CDATA[Customer Support with Slovak]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <city><![CDATA[Sofia]]></city>
+              <region><![CDATA[Sofia]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <content><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
               <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -374,7 +1484,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Turkish.</li>
+<li>- Fluency in Hebrew.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -392,9 +1502,198 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1400 - 1600]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>  
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <city><![CDATA[Sofia]]></city>
+              <region><![CDATA[Sofia]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>  
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <content><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
+<ul>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+</ul>
+<h3>Benefícios Adicionais:</h3>
+<ul>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+</ul>
+<h3>Requisitos:</h3>
+<ul>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[2450]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>  
+              <title><![CDATA[Beauty Advisor with Greek]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Greek.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1059 - 1259]]></salary>
+              <city><![CDATA[Porto]]></city>
+              <region><![CDATA[Porto]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
               <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>  
@@ -437,10 +1736,10 @@
               <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Czech]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>  
+              <title><![CDATA[Content Moderation with German]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -451,7 +1750,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -460,7 +1759,7 @@
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
 <li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
 <li>- Comprehensive health insurance starting from your first day.</li>
 <li>- Performance-based monthly and quarterly bonuses.</li>
@@ -469,777 +1768,14 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <content><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1160 - 1600]]></salary>
+              <salary><![CDATA[1150 - 1250]]></salary>
               <city><![CDATA[Porto]]></city>
               <region><![CDATA[Porto]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1237]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1295]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1100 - 1400]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <content><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Braga]]></city>
-              <region><![CDATA[Braga]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Finnish]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with French]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
-              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
               <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1249]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -1253,7 +1789,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Finnish.</li>
+<li>- Fluency in Norwegian.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1276,61 +1812,23 @@
               <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1339,22 +1837,22 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Sales Advisor with Polish]]></title>
               <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
 <p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
 <h3>Your responsibilities:</h3>
@@ -1372,7 +1870,7 @@
 </ul>
 <h3>Employer requirements:</h3>
 <ul>
-<li>- Fluency in Lithuanian.</li>
+<li>- Fluency in Polish.</li>
 <li>- Communicative English (at least B2 level).</li>
 <li>- Previous experience in sales and/or marketing is preferred.</li>
 <li>- Strong verbal and written communication skills.</li>
@@ -1389,122 +1887,6 @@
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
               <salary><![CDATA[1059 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1260]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
             </ad>
@@ -1550,10 +1932,208 @@
               <region><![CDATA[Porto]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <city><![CDATA[Portugal]]></city>
+              <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -1564,7 +2144,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -1582,15 +2162,91 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>  
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <city><![CDATA[Sofia]]></city>
+              <region><![CDATA[Sofia]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>  
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -1603,7 +2259,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Norwegian.</li>
+<li>- Fluency in Danish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1612,7 +2268,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -1621,45 +2277,311 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1358 - 1620]]></salary>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1200]]></salary>
               <city><![CDATA[Portugal]]></city>
               <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>  
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <content><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <content><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
 <ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
 </ul>
-<h3>Benefícios Adicionais:</h3>
+<h3>O que procuramos:</h3>
 <ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
 </ul>
-<h3>Requisitos:</h3>
+<h3>O que oferecemos:</h3>
 <ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[2450]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <city><![CDATA[Braga]]></city>
+              <region><![CDATA[Braga]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>  
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <content><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <city><![CDATA[Guimarães]]></city>
+              <region><![CDATA[Braga]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>  
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1150]]></salary>
+              <city><![CDATA[Porto]]></city>
+              <region><![CDATA[Porto]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>  
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <content><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>  
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <content><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <city><![CDATA[Porto]]></city>
+              <region><![CDATA[Porto]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1295]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>  
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1250]]></salary>
+              <city><![CDATA[Porto]]></city>
+              <region><![CDATA[Porto]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>  
               <title><![CDATA[Content Moderation with French]]></title>
               <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
@@ -1691,15 +2613,55 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <city><![CDATA[Porto]]></city>
-              <region><![CDATA[Porto]]></region>
+              <salary><![CDATA[1000 - 1306]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
               <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -1713,7 +2675,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Danish.</li>
+<li>- Fluency in Greek.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1731,30 +2693,29 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1358 - 1620]]></salary>
+              <salary><![CDATA[1059 - 1260]]></salary>
               <city><![CDATA[Lisboa]]></city>
               <region><![CDATA[Lisboa]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>  
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -1762,7 +2723,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -1771,9 +2732,9 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <city><![CDATA[Sofia]]></city>
+              <region><![CDATA[Sofia]]></region>
             </ad>
             <ad>
               <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>  
@@ -1817,9 +2778,49 @@
               <region><![CDATA[Porto]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -1833,7 +2834,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Danish.</li>
+<li>- Fluency in Finnish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1856,345 +2857,10 @@
               <region><![CDATA[Portugal]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <content><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <content><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>  
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1150]]></salary>
-              <city><![CDATA[Porto]]></city>
-              <region><![CDATA[Porto]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Bulgarian]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>  
-              <title><![CDATA[Content Moderation with German]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <city><![CDATA[Porto]]></city>
-              <region><![CDATA[Porto]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with German]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>  
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <city><![CDATA[Lisboa]]></city>
-              <region><![CDATA[Lisboa]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <content><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <city><![CDATA[Guimarães]]></city>
-              <region><![CDATA[Braga]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>  
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>  
               <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -2216,7 +2882,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -2225,76 +2891,37 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <city><![CDATA[Portugal]]></city>
-              <region><![CDATA[Portugal]]></region>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>  
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <content><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></content>
-              <company><![CDATA[Recruityard]]></company>
-              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <city><![CDATA[Braga]]></city>
-              <region><![CDATA[Braga]]></region>
-            </ad>
-            <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>  
-              <title><![CDATA[Beauty Advisor with Greek]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>  
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluent level of written and verbal communication skills in Greek.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -2303,15 +2930,55 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1059 - 1259]]></salary>
-              <city><![CDATA[Porto]]></city>
-              <region><![CDATA[Porto]]></region>
+              <salary><![CDATA[2600]]></salary>
+              <city><![CDATA[Bulgaria]]></city>
+              <region><![CDATA[Bulgaria]]></region>
             </ad>
             <ad>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>  
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1500]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>  
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -2324,7 +2991,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Dutch.</li>
+<li>- Fluency in French.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2333,7 +3000,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -2342,8 +3009,84 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
               <company><![CDATA[Recruityard]]></company>
               <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
-              <salary><![CDATA[1100 - 1300]]></salary>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <city><![CDATA[Greece]]></city>
+              <region><![CDATA[Greece]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>  
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <content><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1200]]></salary>
               <city><![CDATA[Portugal]]></city>
               <region><![CDATA[Portugal]]></region>
+            </ad>
+            <ad>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>  
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <content><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></content>
+              <company><![CDATA[Recruityard]]></company>
+              <contract><![CDATA[Efetivo, tempo inteiro]]></contract>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <city><![CDATA[Lisboa]]></city>
+              <region><![CDATA[Lisboa]]></region>
             </ad>
 </jobatus>

--- a/jobrapido.xml
+++ b/jobrapido.xml
@@ -2,7 +2,7 @@
 <source>
 <jobs>
             <job>
-              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
               <location><![CDATA[Lisbon]]></location>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
@@ -11,431 +11,10 @@
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-52]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Czech]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-43]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-60]]></reference_id>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with German]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in German.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-2]]></reference_id>
-              <salary><![CDATA[1084 - 1448]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-68]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-14]]></reference_id>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-66]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-80]]></reference_id>
-              <salary><![CDATA[1237]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Czech]]></title>
-              <location><![CDATA[Sofia]]></location>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-77]]></reference_id>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -446,7 +25,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -462,145 +41,8 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-16]]></reference_id>
+              <reference_id><![CDATA[CC-0506-21]]></reference_id>
               <salary><![CDATA[1350 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Polish - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-65]]></reference_id>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <location><![CDATA[Madrid]]></location>
-              <state><![CDATA[Madrid]]></state>
-              <country><![CDATA[ES]]></country>
-              <postalcode><![CDATA[28001]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-57]]></reference_id>
-              <salary><![CDATA[1750 - 2000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-28]]></reference_id>
-              <salary><![CDATA[1050 - 1306]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
@@ -648,143 +90,7 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-55]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovak]]></title>
-              <location><![CDATA[Sofia]]></location>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-75]]></reference_id>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-84]]></reference_id>
-              <salary><![CDATA[1000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <title><![CDATA[Content Moderation with Danish]]></title>
               <location><![CDATA[Lisbon]]></location>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
@@ -793,1968 +99,10 @@
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-42]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-21]]></reference_id>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-44]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-38]]></reference_id>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-83]]></reference_id>
-              <salary><![CDATA[2450]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-6]]></reference_id>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-86]]></reference_id>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Dutch]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506]]></reference_id>
-              <salary><![CDATA[1050 - 1300]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-54]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-69]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-4]]></reference_id>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0528-04]]></reference_id>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-51]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-79]]></reference_id>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-39]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-59]]></reference_id>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Italian - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-61]]></reference_id>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovenian]]></title>
-              <location><![CDATA[Sofia]]></location>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-78]]></reference_id>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-13]]></reference_id>
-              <salary><![CDATA[1059 - 1350 ]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-31]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0527]]></reference_id>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-24]]></reference_id>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-89]]></reference_id>
-              <salary><![CDATA[1295]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-27]]></reference_id>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-56]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-70]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0528-05]]></reference_id>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-81]]></reference_id>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-18]]></reference_id>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Italian]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-5]]></reference_id>
-              <salary><![CDATA[1040 - 1259]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0528-03]]></reference_id>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-67]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with German]]></title>
-              <location><![CDATA[Sofia]]></location>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-49]]></reference_id>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-10]]></reference_id>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <location><![CDATA[Braga]]></location>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4700]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-53]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-35]]></reference_id>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-71]]></reference_id>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <location><![CDATA[Braga]]></location>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4700]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-19]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with French - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-62]]></reference_id>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-33]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-25]]></reference_id>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
               <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0528-01]]></reference_id>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-20]]></reference_id>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2765,7 +113,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -2781,8 +129,8 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-7]]></reference_id>
-              <salary><![CDATA[1000 - 1150]]></salary>
+              <reference_id><![CDATA[CC-0506-16]]></reference_id>
+              <salary><![CDATA[1350 - 1620]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
@@ -2830,19 +178,19 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <location><![CDATA[Guimarães]]></location>
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
+              <location><![CDATA[Braga]]></location>
               <state><![CDATA[Braga]]></state>
               <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4800]]></postalcode>
+              <postalcode><![CDATA[4700]]></postalcode>
               <company><![CDATA[Recruityard]]></company>
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2853,7 +201,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
+<li>- Fluência em Alemão;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -2866,63 +214,15 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Local de trabalho - Braga</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <reference_id><![CDATA[CC-0527-74]]></reference_id>
-              <salary><![CDATA[1160 - 1600]]></salary>
+              <reference_id><![CDATA[CC-0506-19]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Beauty Advisor with Greek]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Greek.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-3]]></reference_id>
-              <salary><![CDATA[1059 - 1259]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Czech]]></title>
+              <title><![CDATA[Content Moderation with German]]></title>
               <location><![CDATA[Lisbon]]></location>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
@@ -2931,10 +231,10 @@
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2945,325 +245,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-82]]></reference_id>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-15]]></reference_id>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <location><![CDATA[Porto]]></location>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[4000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-12]]></reference_id>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Dutch]]></title>
-              <location><![CDATA[Sofia]]></location>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-50]]></reference_id>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-30]]></reference_id>
-              <salary><![CDATA[1400 - 1600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with French - Remote]]></title>
-              <location><![CDATA[Bulgaria]]></location>
-              <state><![CDATA[Bulgaria]]></state>
-              <country><![CDATA[BG]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-88]]></reference_id>
-              <salary><![CDATA[2600]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-85]]></reference_id>
-              <salary><![CDATA[1100 - 1400]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3279,97 +261,7 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-11]]></reference_id>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <location><![CDATA[Portugal]]></location>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-87]]></reference_id>
-              <salary><![CDATA[1249]]></salary>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <location><![CDATA[Lisbon]]></location>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <postalcode><![CDATA[1000]]></postalcode>
-              <company><![CDATA[Recruityard]]></company>
-              <website><![CDATA[https://www.recruityard.com]]></website>
-              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
-              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-9]]></reference_id>
+              <reference_id><![CDATA[CC-0506-8]]></reference_id>
               <salary><![CDATA[1050 - 1306]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
@@ -3421,7 +313,53 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-67]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Czech]]></title>
               <location><![CDATA[Lisbon]]></location>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
@@ -3430,10 +368,375 @@
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-82]]></reference_id>
+              <salary><![CDATA[1068 - 1270]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-69]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-85]]></reference_id>
+              <salary><![CDATA[1100 - 1400]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-61]]></reference_id>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-71]]></reference_id>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-24]]></reference_id>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with German]]></title>
+              <location><![CDATA[Sofia]]></location>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-49]]></reference_id>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Czech]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-43]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3447,7 +750,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in Turkish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3463,8 +766,54 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <reference_id><![CDATA[CC-0506-36]]></reference_id>
-              <salary><![CDATA[1000 - 1260]]></salary>
+              <reference_id><![CDATA[CC-0506-30]]></reference_id>
+              <salary><![CDATA[1400 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-87]]></reference_id>
+              <salary><![CDATA[1249]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
@@ -3515,33 +864,33 @@
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <location><![CDATA[Greece]]></location>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <postalcode><![CDATA[]]></postalcode>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <location><![CDATA[Madrid]]></location>
+              <state><![CDATA[Madrid]]></state>
+              <country><![CDATA[ES]]></country>
+              <postalcode><![CDATA[28001]]></postalcode>
               <company><![CDATA[Recruityard]]></company>
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
+<li>- Fluency in English</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -3549,19 +898,20 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-32]]></reference_id>
-              <salary><![CDATA[1300 - 1600]]></salary>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-57]]></reference_id>
+              <salary><![CDATA[1750 - 2000]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
-              <title><![CDATA[Content Moderation with German]]></title>
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
               <location><![CDATA[Lisbon]]></location>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
@@ -3570,10 +920,104 @@
               <website><![CDATA[https://www.recruityard.com]]></website>
               <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
               <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
               <email><![CDATA[info@recruityard.com]]></email>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-31]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-80]]></reference_id>
+              <salary><![CDATA[1237]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3584,7 +1028,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3600,8 +1044,102 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <reference_id><![CDATA[CC-0506-8]]></reference_id>
-              <salary><![CDATA[1050 - 1306]]></salary>
+              <reference_id><![CDATA[CC-0506-11]]></reference_id>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-86]]></reference_id>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-35]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
             <job>
@@ -3648,6 +1186,2468 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <reference_id><![CDATA[CC-0528-02]]></reference_id>
               <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with German]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in German.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-2]]></reference_id>
+              <salary><![CDATA[1084 - 1448]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-59]]></reference_id>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-20]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-25]]></reference_id>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-6]]></reference_id>
+              <salary><![CDATA[1000 - 1100]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-9]]></reference_id>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovak]]></title>
+              <location><![CDATA[Sofia]]></location>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-75]]></reference_id>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-79]]></reference_id>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0528-04]]></reference_id>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-70]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-65]]></reference_id>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-54]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hebrew.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-15]]></reference_id>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <location><![CDATA[Sofia]]></location>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-77]]></reference_id>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-28]]></reference_id>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
+<ul>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+</ul>
+<h3>Benefícios Adicionais:</h3>
+<ul>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+</ul>
+<h3>Requisitos:</h3>
+<ul>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-83]]></reference_id>
+              <salary><![CDATA[2450]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Greek]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Greek.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-3]]></reference_id>
+              <salary><![CDATA[1059 - 1259]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0528-01]]></reference_id>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-13]]></reference_id>
+              <salary><![CDATA[1059 - 1350 ]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-4]]></reference_id>
+              <salary><![CDATA[1150 - 1250]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0528-03]]></reference_id>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-33]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-52]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Italian]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-5]]></reference_id>
+              <salary><![CDATA[1040 - 1259]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-38]]></reference_id>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-51]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-84]]></reference_id>
+              <salary><![CDATA[1000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-32]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-81]]></reference_id>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-10]]></reference_id>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <location><![CDATA[Sofia]]></location>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-50]]></reference_id>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-18]]></reference_id>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-66]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-55]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <location><![CDATA[Braga]]></location>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4700]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-53]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <location><![CDATA[Guimarães]]></location>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4800]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0527-74]]></reference_id>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-7]]></reference_id>
+              <salary><![CDATA[1000 - 1150]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-60]]></reference_id>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <reference_id><![CDATA[CC-0527]]></reference_id>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-89]]></reference_id>
+              <salary><![CDATA[1295]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-12]]></reference_id>
+              <salary><![CDATA[1000 - 1250]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-27]]></reference_id>
+              <salary><![CDATA[1000 - 1306]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-42]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-39]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <location><![CDATA[Sofia]]></location>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-78]]></reference_id>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Dutch]]></title>
+              <location><![CDATA[Porto]]></location>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[4000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506]]></reference_id>
+              <salary><![CDATA[1050 - 1300]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-44]]></reference_id>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-28T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-28T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0528-05]]></reference_id>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-68]]></reference_id>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <location><![CDATA[Bulgaria]]></location>
+              <state><![CDATA[Bulgaria]]></state>
+              <country><![CDATA[BG]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-88]]></reference_id>
+              <salary><![CDATA[2600]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-14]]></reference_id>
+              <salary><![CDATA[1000 - 1500]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <location><![CDATA[Greece]]></location>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-62]]></reference_id>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <location><![CDATA[Portugal]]></location>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <reference_id><![CDATA[CC-0506-56]]></reference_id>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>     
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <location><![CDATA[Lisbon]]></location>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <postalcode><![CDATA[1000]]></postalcode>
+              <company><![CDATA[Recruityard]]></company>
+              <website><![CDATA[https://www.recruityard.com]]></website>
+              <publishdate><![CDATA[2025-05-27T00:00:00.000Z]]></publishdate>
+              <expirydate><![CDATA[2025-06-26T00:00:00.000Z]]></expirydate>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <reference_id><![CDATA[CC-0506-36]]></reference_id>
+              <salary><![CDATA[1000 - 1260]]></salary>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>     
             </job>
 </jobs>

--- a/jobsora.xml
+++ b/jobsora.xml
@@ -1,43 +1,657 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobs>
-            <job id="CC-0506-52">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Polish]]></name>
+            <job id="CC-0506-21">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Norwegian]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
 <ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Employer requirements:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt?id=CC-0506-52]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt?id=CC-0506-21]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-17">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Finnish]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt?id=CC-0506-17]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-16">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Danish]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt?id=CC-0506-16]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-23">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Bulgarian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt?id=CC-0506-23]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-19">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Alemão]]></name>
+              <region><![CDATA[Braga]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt?id=CC-0506-19]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-8">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with German]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt?id=CC-0506-8]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-34">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Hungarian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt?id=CC-0506-34]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-67">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr?id=CC-0506-67]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-82">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Czech]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1068 - 1270]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt?id=CC-0506-82]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-69">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Finnish - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr?id=CC-0506-69]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-85">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Turkish - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1100 - 1400]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt?id=CC-0506-85]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-61">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Italian - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr?id=CC-0506-61]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-71">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Hungarian - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr?id=CC-0506-71]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-24">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Russian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt?id=CC-0506-24]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-49">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
+              <name><![CDATA[Customer Support with German]]></name>
+              <region><![CDATA[Sofia]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg?id=CC-0506-49]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -92,16 +706,107 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-60">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Client Services Officer with French]]></name>
+            <job id="CC-0506-30">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Turkish]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+              <salary><![CDATA[1400 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt?id=CC-0506-30]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-87">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Customer Support with Italian - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1249]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt?id=CC-0506-87]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-26">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></link>  
+              <name><![CDATA[Client Services Officer with German]]></name>
+              <region><![CDATA[Madrid]]></region>
+              <country><![CDATA[ES]]></country>
+              <salary><![CDATA[1750 - 2000]]></salary>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -113,7 +818,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French</li>
+<li>- Fluency in German</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -129,369 +834,7 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt?id=CC-0506-60]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-2">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1084 - 1448]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in German.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt?id=CC-0506-2]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-68">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Swedish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr?id=CC-0506-68]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-14">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with German]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt?id=CC-0506-14]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-66">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Danish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr?id=CC-0506-66]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-80">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with English]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1237]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt?id=CC-0506-80]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-77">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Czech]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg?id=CC-0506-77]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-16">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Danish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt?id=CC-0506-16]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-65">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Polish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr?id=CC-0506-65]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es?id=CC-0506-26]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -546,368 +889,14 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-28">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Italian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt?id=CC-0506-28]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-17">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Finnish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt?id=CC-0506-17]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-55">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Interpreter with Russian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt?id=CC-0506-55]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-75">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Slovak]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg?id=CC-0506-75]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-84">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Sales Advisor with French - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt?id=CC-0506-84]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-42">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Hungarian]]></name>
+            <job id="CC-0506-31">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Czech]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt?id=CC-0506-42]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-21">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Norwegian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt?id=CC-0506-21]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-44">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Lithuanian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt?id=CC-0506-44]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-38">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with French]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1260]]></salary>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -921,7 +910,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French.</li>
+<li>- Fluency in Czech.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -937,7 +926,7 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt?id=CC-0506-38]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt?id=CC-0506-31]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -946,53 +935,60 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-83">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
-              <name><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></name>
+            <job id="CC-0506-80">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with English]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1237]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt?id=CC-0506-80]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-11">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Content Moderation with Hebrew - Remote]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[2450]]></salary>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt?id=CC-0506-83]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-6">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with French]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -1003,7 +999,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -1019,7 +1015,7 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt?id=CC-0506-6]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt?id=CC-0506-11]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -1074,328 +1070,14 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with Dutch]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt?id=CC-0506]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-54">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês - Remoto]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt?id=CC-0506-54]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-69">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Finnish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr?id=CC-0506-69]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-4">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt?id=CC-0506-4]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0528-04">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt?id=CC-0528-04]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-51">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Estonian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt?id=CC-0506-51]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-79">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Dutch - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt?id=CC-0506-79]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-39">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Greek]]></name>
+            <job id="CC-0506-35">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Polish]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1059 - 1260]]></salary>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -1409,7 +1091,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Greek.</li>
+<li>- Fluency in Polish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1425,7 +1107,99 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt?id=CC-0506-39]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt?id=CC-0506-35]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0528-02">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Swedish - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt?id=CC-0528-02]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-28T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-2">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
+              <name><![CDATA[Beauty Advisor with German]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1084 - 1448]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in German.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt?id=CC-0506-2]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -1480,950 +1254,14 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-61">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Italian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr?id=CC-0506-61]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-78">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Slovenian]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg?id=CC-0506-78]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-13">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Dutch]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1350 ]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt?id=CC-0506-13]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-31">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Czech]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt?id=CC-0506-31]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0527">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt?id=CC-0527]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-24">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Russian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt?id=CC-0506-24]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-89">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Arabic]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1295]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt?id=CC-0506-89]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-27">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with French]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt?id=CC-0506-27]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-56">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Interpreter with Ukrainian - Remote]]></name>
+            <job id="CC-0506-20">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt?id=CC-0506-56]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-70">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr?id=CC-0506-70]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0528-05">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Finnish - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt?id=CC-0528-05]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-81">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with German - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt?id=CC-0506-81]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-18">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Swedish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt?id=CC-0506-18]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-5">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with Italian]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1040 - 1259]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt?id=CC-0506-5]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0528-03">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt?id=CC-0528-03]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-67">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr?id=CC-0506-67]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-49">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with German]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg?id=CC-0506-49]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-10">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Hebrew]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt?id=CC-0506-10]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-53">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt?id=CC-0506-53]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-35">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Polish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt?id=CC-0506-35]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-71">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Hungarian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr?id=CC-0506-71]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-19">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Alemão]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2447,100 +1285,10 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
+<li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt?id=CC-0506-19]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-62">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with French - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr?id=CC-0506-62]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-33">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Dutch - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr?id=CC-0506-33]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt?id=CC-0506-20]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -2592,13 +1340,144 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0528-01">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Danish - Remote]]></name>
+            <job id="CC-0506-6">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
+              <name><![CDATA[Content Moderation with French]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1100]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt?id=CC-0506-6]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-9">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Dutch]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1306]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt?id=CC-0506-9]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-75">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
+              <name><![CDATA[Customer Support with Slovak]]></name>
+              <region><![CDATA[Sofia]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg?id=CC-0506-75]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-79">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Dutch - Remote]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -2612,7 +1491,52 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Danish.</li>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt?id=CC-0506-79]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0528-04">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2628,7 +1552,7 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt?id=CC-0528-01]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt?id=CC-0528-04]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -2637,14 +1561,104 @@
               <expire>2025-06-28T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-20">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></name>
+            <job id="CC-0506-70">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr?id=CC-0506-70]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-65">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Polish - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr?id=CC-0506-65]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-54">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Francês - Remoto]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1000 - 1200]]></salary>
               <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2655,7 +1669,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Alemão;</li>
+<li>- Fluência em Francês;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -2671,7 +1685,7 @@
 <li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt?id=CC-0506-20]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt?id=CC-0506-54]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -2680,12 +1694,103 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-7">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with Italian]]></name>
-              <region><![CDATA[Porto]]></region>
+            <job id="CC-0506-15">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Hebrew]]></name>
+              <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1150]]></salary>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hebrew.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt?id=CC-0506-15]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-77">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
+              <name><![CDATA[Customer Support with Czech]]></name>
+              <region><![CDATA[Sofia]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg?id=CC-0506-77]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-28">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Italian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1306]]></salary>
               <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
@@ -2714,7 +1819,7 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt?id=CC-0506-7]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt?id=CC-0506-28]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -2723,84 +1828,37 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-23">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Bulgarian]]></name>
-              <region><![CDATA[Lisbon]]></region>
+            <job id="CC-0506-83">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
+              <name><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></name>
+              <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
+              <salary><![CDATA[2450]]></salary>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
 <ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
 </ul>
-<h3>Requirements:</h3>
+<h3>Benefícios Adicionais:</h3>
 <ul>
-<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
 </ul>
-<h3>Benefits:</h3>
+<h3>Requisitos:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt?id=CC-0506-23]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0527-74">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt?id=CC-0527-74]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt?id=CC-0506-83]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -2856,279 +1914,13 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-82">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Czech]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt?id=CC-0506-82]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-15">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Hebrew]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt?id=CC-0506-15]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-12">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Customer Service Agent - Banking Company with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt?id=CC-0506-12]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-50">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Dutch]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg?id=CC-0506-50]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-30">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Turkish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1400 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt?id=CC-0506-30]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-88">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
-              <name><![CDATA[Customer Support with French - Remote]]></name>
-              <region><![CDATA[Bulgaria]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[2600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg?id=CC-0506-88]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-85">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Turkish - Remote]]></name>
+            <job id="CC-0528-01">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Danish - Remote]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1400]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -3142,7 +1934,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Turkish.</li>
+<li>- Fluency in Danish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3158,7 +1950,53 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt?id=CC-0506-85]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt?id=CC-0528-01]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-28T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-13">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Dutch]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1350 ]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt?id=CC-0506-13]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3167,14 +2005,14 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-11">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Content Moderation with Hebrew - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
+            <job id="CC-0506-4">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
+              <name><![CDATA[Content Moderation with German]]></name>
+              <region><![CDATA[Porto]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+              <salary><![CDATA[1150 - 1250]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3185,7 +2023,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3201,7 +2039,7 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt?id=CC-0506-11]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt?id=CC-0506-4]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3210,16 +2048,16 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-87">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Customer Support with Italian - Remote]]></name>
+            <job id="CC-0528-03">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1249]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
+              <salary><![CDATA[1358 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -3230,8 +2068,8 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -3245,81 +2083,37 @@
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt?id=CC-0506-87]]></apply_url>
-              <email><![CDATA[info@recruityard.com]]></email>
-              <phone><![CDATA[]]></phone>
-              <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype><![CDATA[FULL_TIME]]></jobtype>
-            </job>
-            <job id="CC-0506-9">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Dutch]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt?id=CC-0506-9]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt?id=CC-0528-03]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
               <updated>undisclosed</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
+              <expire>2025-06-28T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-34">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Hungarian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+            <job id="CC-0506-33">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Dutch - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3328,14 +2122,14 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt?id=CC-0506-34]]></apply_url>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr?id=CC-0506-33]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3344,14 +2138,107 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-36">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Italian]]></name>
+            <job id="CC-0506-52">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Sales Advisor with Polish]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt?id=CC-0506-52]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-5">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
+              <name><![CDATA[Beauty Advisor with Italian]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1040 - 1259]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt?id=CC-0506-5]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-38">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with French]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1000 - 1260]]></salary>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3365,7 +2252,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in French.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3381,7 +2268,7 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt?id=CC-0506-36]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt?id=CC-0506-38]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3390,44 +2277,90 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-26">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></link>  
-              <name><![CDATA[Client Services Officer with German]]></name>
-              <region><![CDATA[Madrid]]></region>
-              <country><![CDATA[ES]]></country>
-              <salary><![CDATA[1750 - 2000]]></salary>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
+            <job id="CC-0506-51">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Sales Advisor with Estonian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
 <ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
 </ul>
-<h3>What You Need:</h3>
+<h3>Employer requirements:</h3>
 <ul>
-<li>- Fluency in German</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
 </ul>
-<h3>What We Offer:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es?id=CC-0506-26]]></apply_url>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt?id=CC-0506-51]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-84">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Sales Advisor with French - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt?id=CC-0506-84]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3481,14 +2414,59 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0506-8">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with German]]></name>
+            <job id="CC-0506-81">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with German - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt?id=CC-0506-81]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-10">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Hebrew]]></name>
               <region><![CDATA[Lisbon]]></region>
               <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <salary><![CDATA[1450 - 1750]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3499,7 +2477,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3515,7 +2493,7 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt?id=CC-0506-8]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt?id=CC-0506-10]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
@@ -3524,14 +2502,812 @@
               <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
-            <job id="CC-0528-02">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Swedish - Remote]]></name>
+            <job id="CC-0506-50">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
+              <name><![CDATA[Customer Support with Dutch]]></name>
+              <region><![CDATA[Sofia]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg?id=CC-0506-50]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-18">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with Swedish]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1350 - 1620]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt?id=CC-0506-18]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-66">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Danish - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr?id=CC-0506-66]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-55">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Interpreter with Russian - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt?id=CC-0506-55]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-53">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+              <region><![CDATA[Braga]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt?id=CC-0506-53]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0527-74">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+              <region><![CDATA[Braga]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt?id=CC-0527-74]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-7">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
+              <name><![CDATA[Content Moderation with Italian]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1150]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt?id=CC-0506-7]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-60">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
+              <name><![CDATA[Client Services Officer with French]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1100 - 1300]]></salary>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt?id=CC-0506-60]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0527">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
+              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1160 - 1600]]></salary>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt?id=CC-0527]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-89">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Arabic]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1295]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt?id=CC-0506-89]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-12">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
+              <name><![CDATA[Customer Service Agent - Banking Company with German]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1250]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt?id=CC-0506-12]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-27">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
+              <name><![CDATA[Content Moderation with French]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1306]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt?id=CC-0506-27]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-42">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Sales Advisor with Hungarian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt?id=CC-0506-42]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-39">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Greek]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt?id=CC-0506-39]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-78">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
+              <name><![CDATA[Customer Support with Slovenian]]></name>
+              <region><![CDATA[Sofia]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[3000 - 5000]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg?id=CC-0506-78]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
+              <name><![CDATA[Beauty Advisor with Dutch]]></name>
+              <region><![CDATA[Porto]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1050 - 1300]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt?id=CC-0506]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-44">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Sales Advisor with Lithuanian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1059 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt?id=CC-0506-44]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0528-05">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Client Support with Finnish - Remote]]></name>
               <region><![CDATA[Portugal]]></region>
               <country><![CDATA[PT]]></country>
               <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt?id=CC-0528-05]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-28T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-68">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with Swedish - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1300 - 1600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -3553,20 +3329,244 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt?id=CC-0528-02]]></apply_url>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr?id=CC-0506-68]]></apply_url>
               <email><![CDATA[info@recruityard.com]]></email>
               <phone><![CDATA[]]></phone>
               <company><![CDATA[Recruityard]]></company>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
               <updated>undisclosed</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-88">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
+              <name><![CDATA[Customer Support with French - Remote]]></name>
+              <region><![CDATA[Bulgaria]]></region>
+              <country><![CDATA[BG]]></country>
+              <salary><![CDATA[2600]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg?id=CC-0506-88]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-14">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with German]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1500]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt?id=CC-0506-14]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-62">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
+              <name><![CDATA[Client Support with French - Remote]]></name>
+              <region><![CDATA[Greece]]></region>
+              <country><![CDATA[GR]]></country>
+              <salary><![CDATA[1045 - 1200]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr?id=CC-0506-62]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-56">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
+              <name><![CDATA[Interpreter with Ukrainian - Remote]]></name>
+              <region><![CDATA[Portugal]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1200]]></salary>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt?id=CC-0506-56]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
+              <jobtype><![CDATA[FULL_TIME]]></jobtype>
+            </job>
+            <job id="CC-0506-36">
+              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
+              <name><![CDATA[Customer Support for Social Media with Italian]]></name>
+              <region><![CDATA[Lisbon]]></region>
+              <country><![CDATA[PT]]></country>
+              <salary><![CDATA[1000 - 1260]]></salary>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <apply_url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt?id=CC-0506-36]]></apply_url>
+              <email><![CDATA[info@recruityard.com]]></email>
+              <phone><![CDATA[]]></phone>
+              <company><![CDATA[Recruityard]]></company>
+              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+              <updated>undisclosed</updated>
+              <expire>2025-06-26T00:00:00.000Z</expire>
               <jobtype><![CDATA[FULL_TIME]]></jobtype>
             </job>
 </jobs>

--- a/jooble.xml
+++ b/jooble.xml
@@ -1,57 +1,657 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobs>
-            <job id="CC-0506-52">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Polish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
+        <job id="CC-0506-21">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Norwegian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1350 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
 <ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Employer requirements:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:30.215718</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-43">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Czech]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.321483</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-17">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Finnish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1350 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.332052</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-16">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Danish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1350 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.333451</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-23">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Bulgarian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.336561</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-19">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Alemão]]></name>
+            <region><![CDATA[Braga]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.337400</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-8">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with German]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.338951</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-34">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Hungarian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.339538</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-67">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Norwegian - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.340222</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-82">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Czech]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1068 - 1270]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.342676</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-69">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Finnish - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.344261</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-85">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Turkish - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1100 - 1400]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.348346</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-61">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Italian - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1045 - 1200]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.352500</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-71">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Hungarian - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1045 - 1200]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.353473</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-24">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Russian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.354409</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-49">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
+            <name><![CDATA[Customer Support with German]]></name>
+            <region><![CDATA[Sofia]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[3000 - 5000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.355094</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-43">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></link>  
+            <name><![CDATA[Sales Advisor with Czech]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
 <p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
 <h3>Your responsibilities:</h3>
 <ul>
@@ -82,24 +682,113 @@
 <li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:31.294920</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-60">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Client Services Officer with French]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.355760</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-30">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Turkish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1400 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.356368</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-87">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Customer Support with Italian - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1249]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.358606</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-26">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></link>  
+            <name><![CDATA[Client Services Officer with German]]></name>
+            <region><![CDATA[Madrid]]></region>
+            <country><![CDATA[ES]]></country>
+            <salary><![CDATA[1750 - 2000]]></salary>
+            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -111,7 +800,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French</li>
+<li>- Fluency in German</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -127,21 +816,332 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:32.373524</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-2">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1084 - 1448]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.363903</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-57">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></link>  
+            <name><![CDATA[Client Services Officer with English]]></name>
+            <region><![CDATA[Madrid]]></region>
+            <country><![CDATA[ES]]></country>
+            <salary><![CDATA[1750 - 2000]]></salary>
+            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.365860</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-31">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Czech]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.369780</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-80">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with English]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1237]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.371037</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-11">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Content Moderation with Hebrew - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1450 - 1750]]></salary>
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.371867</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-86">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Danish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.372652</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-35">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Polish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.374357</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0528-02">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Swedish - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.379214</updated>
+            <expire>2025-06-28T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-2">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
+            <name><![CDATA[Beauty Advisor with German]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1084 - 1448]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
 <p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
 <p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
 <p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
@@ -173,1242 +1173,21 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:33.452102</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-68">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Swedish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:34.532328</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-14">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with German]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1500]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:35.609882</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-66">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Danish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:36.683498</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-80">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with English]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1237]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:37.782930</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-77">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Czech]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:38.853648</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-16">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Danish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:39.928757</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-65">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Polish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:41.000284</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-57">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></link>  
-              <name><![CDATA[Client Services Officer with English]]></name>
-              <region><![CDATA[Madrid]]></region>
-              <country><![CDATA[ES]]></country>
-              <salary><![CDATA[1750 - 2000]]></salary>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:42.070441</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-28">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Italian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:43.142072</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-17">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Finnish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:44.212670</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-55">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Interpreter with Russian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:45.283158</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-75">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Slovak]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:46.355544</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-84">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Sales Advisor with French - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:47.425747</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-42">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Hungarian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:48.496620</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-21">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Norwegian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:49.566633</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-44">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Lithuanian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:50.637324</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-38">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with French]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:51.708322</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-83">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
-              <name><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[2450]]></salary>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:52.780190</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-6">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with French]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1100]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:53.851378</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-86">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Danish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:54.921633</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with Dutch]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:55.992634</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-54">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês - Remoto]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:57.063114</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-69">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Finnish - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:58.132941</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-4">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1150 - 1250]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:24:59.204653</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0528-04">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:00.275008</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-51">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Sales Advisor with Estonian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:01.347317</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-79">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Dutch - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:02.417366</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-39">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Greek]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:03.488253</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-59">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></link>  
-              <name><![CDATA[Client Services Officer with English]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.380104</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-59">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></link>  
+            <name><![CDATA[Client Services Officer with English]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1100 - 1300]]></salary>
+            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
 <p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
 <p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
@@ -1439,200 +1218,22 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:04.559233</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-61">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Italian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:05.631978</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-78">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Slovenian]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:06.729867</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-13">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Dutch]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1350 ]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:07.800340</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-31">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Czech]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:08.873971</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0527">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.381420</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-20">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -1643,7 +1244,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
+<li>- Fluência em Alemão;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -1656,25 +1257,25 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
+<li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:09.944067</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-24">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Russian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.382322</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-25">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Ukrainian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -1685,7 +1286,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -1701,66 +1302,21 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:11.014624</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-89">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Arabic]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1295]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:12.086975</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-27">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with French]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.383253</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-6">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
+            <name><![CDATA[Content Moderation with French]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1100]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
@@ -1788,62 +1344,195 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:13.157360</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-56">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Interpreter with Ukrainian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.384232</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-9">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Dutch]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Qualifications:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
-<h3>Training and Development:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:14.228306</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-70">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Icelandic - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.385379</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-75">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
+            <name><![CDATA[Customer Support with Slovak]]></name>
+            <region><![CDATA[Sofia]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[3000 - 5000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.386723</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-79">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Dutch - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1100 - 1300]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.387858</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0528-04">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Icelandic - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.393409</updated>
+            <expire>2025-06-28T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-70">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Icelandic - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -1873,241 +1562,21 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:15.298279</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0528-05">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Finnish - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:16.369143</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-81">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with German - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1300]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:17.440964</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-18">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Swedish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1350 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:18.511166</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-5">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with Italian]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1040 - 1259]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:19.584045</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0528-03">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:20.663515</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-67">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Norwegian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.395079</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-65">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Polish - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1045 - 1200]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -2121,7 +1590,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Norwegian.</li>
+<li>- Fluency in Polish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2137,108 +1606,22 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:21.734263</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-49">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with German]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:22.803890</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-10">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Hebrew]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:23.876409</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-53">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.396274</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-54">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Francês - Remoto]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2262,25 +1645,25 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
+<li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:24.946863</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-35">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Polish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.397433</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-15">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Hebrew]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1450 - 1750]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2294,7 +1677,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
+<li>- Fluency in Hebrew.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2310,24 +1693,24 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:26.016688</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-71">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Hungarian - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.398952</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-77">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
+            <name><![CDATA[Customer Support with Czech]]></name>
+            <region><![CDATA[Sofia]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[3000 - 5000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -2338,8 +1721,8 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -2347,286 +1730,28 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:27.087747</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-19">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Alemão]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:28.158150</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-62">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with French - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1045 - 1200]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:29.228606</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-33">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with Dutch - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:30.299414</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-25">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Ukrainian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:31.373966</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0528-01">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Danish - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:32.444231</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-20">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1200]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:33.514241</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-7">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
-              <name><![CDATA[Content Moderation with Italian]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1150]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.399733</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-28">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Italian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
@@ -2654,105 +1779,59 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:34.609966</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-23">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Bulgarian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.402921</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-83">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
+            <name><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[2450]]></salary>
+            <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
 <ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
 </ul>
-<h3>Requirements:</h3>
+<h3>Benefícios Adicionais:</h3>
 <ul>
-<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
 </ul>
-<h3>Benefits:</h3>
+<h3>Requisitos:</h3>
 <ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:35.680078</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0527-74">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
-              <name><![CDATA[Apoio ao Cliente com Francês]]></name>
-              <region><![CDATA[Braga]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1160 - 1600]]></salary>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:36.753304</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-3">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></link>  
-              <name><![CDATA[Beauty Advisor with Greek]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1259]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.404548</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-3">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></link>  
+            <name><![CDATA[Beauty Advisor with Greek]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1259]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
 <p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
 <p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
 <p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
@@ -2784,64 +1863,66 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:37.825614</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-82">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Czech]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1068 - 1270]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.405311</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0528-01">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Danish - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
 <ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
 </ul>
-<h3>Requirements:</h3>
+<h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
 </ul>
-<h3>Benefits:</h3>
+<h3>What We Offer:</h3>
 <ul>
 <li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:38.895335</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-15">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Hebrew]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.406197</updated>
+            <expire>2025-06-28T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-13">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Dutch]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1350 ]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2855,7 +1936,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hebrew.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2871,21 +1952,66 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:39.966297</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-12">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
-              <name><![CDATA[Customer Service Agent - Banking Company with German]]></name>
-              <region><![CDATA[Porto]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1250]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.406720</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-4">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
+            <name><![CDATA[Content Moderation with German]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1150 - 1250]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.407429</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0528-03">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Norwegian - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -2896,11 +2022,147 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.408737</updated>
+            <expire>2025-06-28T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-33">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Dutch - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.409627</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-52">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Sales Advisor with Polish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.412526</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-5">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
+            <name><![CDATA[Beauty Advisor with Italian]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1040 - 1259]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
 </ul>
 <h3>What We Offer:</h3>
 <ul>
@@ -2911,21 +2173,286 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:41.036393</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-50">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
-              <name><![CDATA[Customer Support with Dutch]]></name>
-              <region><![CDATA[Sofia]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[3000 - 5000]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.414524</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-38">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with French]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.415218</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-51">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Sales Advisor with Estonian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.418395</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-84">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Sales Advisor with French - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.423194</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-32">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with German - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.425643</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-81">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with German - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1100 - 1300]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.427551</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-10">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Hebrew]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1450 - 1750]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.428293</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-50">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
+            <name><![CDATA[Customer Support with Dutch]]></name>
+            <region><![CDATA[Sofia]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[3000 - 5000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
 <p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
 <p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
 <p>Take the next step in your career by working with some of the top global brands.</p>
@@ -2955,22 +2482,362 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:42.106491</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-30">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Turkish]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1400 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.430266</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-18">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with Swedish]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1350 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.431877</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-66">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Danish - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.433199</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-55">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Interpreter with Russian - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.434549</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-53">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+            <region><![CDATA[Braga]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.437243</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0527-74">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+            <region><![CDATA[Braga]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1160 - 1600]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.438214</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-7">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
+            <name><![CDATA[Content Moderation with Italian]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1150]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.438922</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-60">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
+            <name><![CDATA[Client Services Officer with French]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1100 - 1300]]></salary>
+            <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.439492</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0527">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
+            <name><![CDATA[Apoio ao Cliente com Francês]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1160 - 1600]]></salary>
+            <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.440055</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-89">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Arabic]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1295]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2984,7 +2851,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Turkish.</li>
+<li>- Fluency in Arabic.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3000,21 +2867,416 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:43.178057</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-88">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
-              <name><![CDATA[Customer Support with French - Remote]]></name>
-              <region><![CDATA[Bulgaria]]></region>
-              <country><![CDATA[BG]]></country>
-              <salary><![CDATA[2600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.442089</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-12">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
+            <name><![CDATA[Customer Service Agent - Banking Company with German]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1250]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.443794</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-27">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
+            <name><![CDATA[Content Moderation with French]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1306]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.445576</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-42">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Sales Advisor with Hungarian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.448283</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-39">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Greek]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.450220</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-78">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
+            <name><![CDATA[Customer Support with Slovenian]]></name>
+            <region><![CDATA[Sofia]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[3000 - 5000]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.453021</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
+            <name><![CDATA[Beauty Advisor with Dutch]]></name>
+            <region><![CDATA[Porto]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1050 - 1300]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.453685</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-44">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Sales Advisor with Lithuanian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1059 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.454354</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0528-05">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Client Support with Finnish - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1358 - 1620]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-28T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.455850</updated>
+            <expire>2025-06-28T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-68">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with Swedish - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1300 - 1600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.456733</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-88">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
+            <name><![CDATA[Customer Support with French - Remote]]></name>
+            <region><![CDATA[Bulgaria]]></region>
+            <country><![CDATA[BG]]></country>
+            <salary><![CDATA[2600]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
 <p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
 <p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
 <p>Take the next step in your career by working with some of the top global brands.</p>
@@ -3044,194 +3306,22 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:44.248533</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-85">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Turkish - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1100 - 1400]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:45.318988</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-11">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Content Moderation with Hebrew - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1450 - 1750]]></salary>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:46.389169</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-87">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Customer Support with Italian - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1249]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:47.460516</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-9">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with Dutch]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:48.531219</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-34">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Hungarian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1059 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.459014</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-14">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with German]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1500]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3245,7 +3335,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
+<li>- Fluency in German.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3261,21 +3351,106 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:49.601408</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-36">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
-              <name><![CDATA[Customer Support for Social Media with Italian]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1000 - 1260]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.460171</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-62">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
+            <name><![CDATA[Client Support with French - Remote]]></name>
+            <region><![CDATA[Greece]]></region>
+            <country><![CDATA[GR]]></country>
+            <salary><![CDATA[1045 - 1200]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.463527</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-56">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
+            <name><![CDATA[Interpreter with Ukrainian - Remote]]></name>
+            <region><![CDATA[Portugal]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1200]]></salary>
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.465382</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
+        <job id="CC-0506-36">
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
+            <name><![CDATA[Customer Support for Social Media with Italian]]></name>
+            <region><![CDATA[Lisbon]]></region>
+            <country><![CDATA[PT]]></country>
+            <salary><![CDATA[1000 - 1260]]></salary>
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
 <p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
@@ -3306,187 +3481,12 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:50.672319</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-26">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></link>  
-              <name><![CDATA[Client Services Officer with German]]></name>
-              <region><![CDATA[Madrid]]></region>
-              <country><![CDATA[ES]]></country>
-              <salary><![CDATA[1750 - 2000]]></salary>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:51.742240</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-32">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></link>  
-              <name><![CDATA[Client Support with German - Remote]]></name>
-              <region><![CDATA[Greece]]></region>
-              <country><![CDATA[GR]]></country>
-              <salary><![CDATA[1300 - 1600]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:52.814119</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0506-8">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
-              <name><![CDATA[Content Moderation with German]]></name>
-              <region><![CDATA[Lisbon]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1050 - 1306]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-27T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:53.884015</updated>
-              <expire>2025-06-26T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
-            <job id="CC-0528-02">
-              <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></link>  
-              <name><![CDATA[Client Support with Swedish - Remote]]></name>
-              <region><![CDATA[Portugal]]></region>
-              <country><![CDATA[PT]]></country>
-              <salary><![CDATA[1358 - 1620]]></salary>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <company><![CDATA[Recruityard]]></company>
-              <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
-              <pubdate>2025-05-28T00:00:00.000Z</pubdate>
-              <updated>2025-06-16T10:25:54.955993</updated>
-              <expire>2025-06-28T00:00:00.000Z</expire>
-              <jobtype>Full time</jobtype>
-              <email><![CDATA[info@recruityard.com]]></email>        
-            </job>
+            <company><![CDATA[Recruityard]]></company>
+            <company_logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=15]]></company_logo>
+            <pubdate>2025-05-27T00:00:00.000Z</pubdate>
+            <updated>2025-06-17T01:11:19.467016</updated>
+            <expire>2025-06-26T00:00:00.000Z</expire>
+            <jobtype>Full time</jobtype>
+            <email><![CDATA[info@recruityard.com]]></email>        
+        </job>
 </jobs>

--- a/jora.xml
+++ b/jora.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <source>
     <publisher>Recruityard</publisher>
-    <lastBuildDate>2025-06-16T10:27:23.495438</lastBuildDate>
+    <lastBuildDate>2025-06-17T01:11:19.667879</lastBuildDate>
             <job>
-              <title><![CDATA[Sales Advisor with Polish]]></title>
-              <id><![CDATA[CC-0506-52]]></id>
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
+              <id><![CDATA[CC-0506-21]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -12,37 +12,319 @@
               <state><![CDATA[Lisbon]]></state>
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
 <ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Employer requirements:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
 <h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1350</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Finnish]]></title>
+              <id><![CDATA[CC-0506-17]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1350</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Danish]]></title>
+              <id><![CDATA[CC-0506-16]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1350</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Bulgarian]]></title>
+              <id><![CDATA[CC-0506-23]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1050</min>
+                <max>1306</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
+              <id><![CDATA[CC-0506-19]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Braga]]></location>
+              <city><![CDATA[Braga]]></city>
+              <state><![CDATA[Braga]]></state>
+              <postalcode>4700</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <id><![CDATA[CC-0506-8]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1050</min>
+                <max>1306</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
+              <id><![CDATA[CC-0506-34]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
                 <type>Monthly</type>
                 <min>1059</min>
@@ -50,7 +332,395 @@
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <id><![CDATA[CC-0506-67]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1300</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Czech]]></title>
+              <id><![CDATA[CC-0506-82]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1068</min>
+                <max>1270</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <id><![CDATA[CC-0506-69]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1300</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <id><![CDATA[CC-0506-85]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1100</min>
+                <max>1400</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <id><![CDATA[CC-0506-61]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1045</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <id><![CDATA[CC-0506-71]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1045</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <id><![CDATA[CC-0506-24]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1050</min>
+                <max>1306</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with German]]></title>
+              <id><![CDATA[CC-0506-49]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[BG]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>3000</min>
+                <max>5000</max>
+                <currency>BGN</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
             </job>
             <job>
               <title><![CDATA[Sales Advisor with Czech]]></title>
@@ -103,8 +773,8 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <id><![CDATA[CC-0506-60]]></id>
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <id><![CDATA[CC-0506-30]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -112,10 +782,109 @@
               <state><![CDATA[Lisbon]]></state>
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1400</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <id><![CDATA[CC-0506-87]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1249</min>
+                <max>1249</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with German]]></title>
+              <id><![CDATA[CC-0506-26]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Madrid]]></location>
+              <city><![CDATA[Madrid]]></city>
+              <state><![CDATA[Madrid]]></state>
+              <postalcode>28001</postalcode>
+              <country><![CDATA[ES]]></country>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -127,7 +896,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in French</li>
+<li>- Fluency in German</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -145,12 +914,358 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1100</min>
-                <max>1300</max>
+                <min>1750</min>
+                <max>2000</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <id><![CDATA[CC-0506-57]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Madrid]]></location>
+              <city><![CDATA[Madrid]]></city>
+              <state><![CDATA[Madrid]]></state>
+              <postalcode>28001</postalcode>
+              <country><![CDATA[ES]]></country>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1750</min>
+                <max>2000</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+              <id><![CDATA[CC-0506-31]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
+              <id><![CDATA[CC-0506-80]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1237</min>
+                <max>1237</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <id><![CDATA[CC-0506-11]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1450</min>
+                <max>1750</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <id><![CDATA[CC-0506-86]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1358</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+              <id><![CDATA[CC-0506-35]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <id><![CDATA[CC-0528-02]]></id>
+              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1358</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>
             </job>
             <job>
               <title><![CDATA[Beauty Advisor with German]]></title>
@@ -204,362 +1319,19 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <id><![CDATA[CC-0506-68]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1300</min>
-                <max>1600</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <id><![CDATA[CC-0506-14]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1500</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <id><![CDATA[CC-0506-66]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1300</min>
-                <max>1600</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <id><![CDATA[CC-0506-80]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1237</min>
-                <max>1237</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Czech]]></title>
-              <id><![CDATA[CC-0506-77]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[BG]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>3000</min>
-                <max>5000</max>
-                <currency>BGN</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <id><![CDATA[CC-0506-16]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1350</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Polish - Remote]]></title>
-              <id><![CDATA[CC-0506-65]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1045</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
-            </job>
-            <job>
               <title><![CDATA[Client Services Officer with English]]></title>
-              <id><![CDATA[CC-0506-57]]></id>
+              <id><![CDATA[CC-0506-59]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Madrid]]></location>
-              <city><![CDATA[Madrid]]></city>
-              <state><![CDATA[Madrid]]></state>
-              <postalcode>28001</postalcode>
-              <country><![CDATA[ES]]></country>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
               <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
 <p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
@@ -589,16 +1361,63 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1750</min>
-                <max>2000</max>
+                <min>1100</min>
+                <max>1300</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <id><![CDATA[CC-0506-28]]></id>
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <id><![CDATA[CC-0506-20]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <id><![CDATA[CC-0506-25]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -606,8 +1425,8 @@
               <state><![CDATA[Lisbon]]></state>
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -618,7 +1437,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -641,20 +1460,20 @@
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with Finnish]]></title>
-              <id><![CDATA[CC-0506-17]]></id>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <id><![CDATA[CC-0506-6]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Finnish-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -665,7 +1484,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Finnish; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -683,58 +1502,59 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1350</min>
-                <max>1620</max>
+                <min>1000</min>
+                <max>1100</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-finnish-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
-              <id><![CDATA[CC-0506-55]]></id>
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <id><![CDATA[CC-0506-9]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
 </ul>
-<h3>Qualifications:</h3>
+<h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
 </ul>
-<h3>Training and Development:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1000</min>
-                <max>1200</max>
+                <min>1050</min>
+                <max>1306</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
             </job>
             <job>
               <title><![CDATA[Customer Support with Slovak]]></title>
@@ -786,8 +1606,8 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
             </job>
             <job>
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <id><![CDATA[CC-0506-84]]></id>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <id><![CDATA[CC-0506-79]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Portugal]]></location>
@@ -795,493 +1615,8 @@
               <state><![CDATA[Portugal]]></state>
               <postalcode></postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1000</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
-              <id><![CDATA[CC-0506-42]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
-              <id><![CDATA[CC-0506-21]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1350</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-              <id><![CDATA[CC-0506-44]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <id><![CDATA[CC-0506-38]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <id><![CDATA[CC-0506-83]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>2450</min>
-                <max>2450</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <id><![CDATA[CC-0506-6]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1100</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-              <id><![CDATA[CC-0506-86]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1358</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Dutch]]></title>
-              <id><![CDATA[CC-0506]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1050</min>
-                <max>1300</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <id><![CDATA[CC-0506-54]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <id><![CDATA[CC-0506-69]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
 <h3>What You Will Do:</h3>
@@ -1294,7 +1629,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Finnish.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -1303,7 +1638,7 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -1312,59 +1647,12 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1300</min>
-                <max>1600</max>
+                <min>1100</min>
+                <max>1300</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <id><![CDATA[CC-0506-4]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1150</min>
-                <max>1250</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
             </job>
             <job>
               <title><![CDATA[Client Support with Icelandic - Remote]]></title>
@@ -1416,640 +1704,6 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <id><![CDATA[CC-0506-51]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <id><![CDATA[CC-0506-79]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1100</min>
-                <max>1300</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <id><![CDATA[CC-0506-39]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <id><![CDATA[CC-0506-59]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1100</min>
-                <max>1300</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Italian - Remote]]></title>
-              <id><![CDATA[CC-0506-61]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1045</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovenian]]></title>
-              <id><![CDATA[CC-0506-78]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[BG]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>3000</min>
-                <max>5000</max>
-                <currency>BGN</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-              <id><![CDATA[CC-0506-13]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1350</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <id><![CDATA[CC-0506-31]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <id><![CDATA[CC-0527]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1160</min>
-                <max>1600</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <id><![CDATA[CC-0506-24]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1050</min>
-                <max>1306</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <id><![CDATA[CC-0506-89]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1295</min>
-                <max>1295</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <id><![CDATA[CC-0506-27]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1306</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <id><![CDATA[CC-0506-56]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
               <title><![CDATA[Client Support with Icelandic - Remote]]></title>
               <id><![CDATA[CC-0506-70]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
@@ -2099,253 +1753,8 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <id><![CDATA[CC-0528-05]]></id>
-              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1358</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <id><![CDATA[CC-0506-81]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1100</min>
-                <max>1300</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <id><![CDATA[CC-0506-18]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1350</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Italian]]></title>
-              <id><![CDATA[CC-0506-5]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1040</min>
-                <max>1259</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <id><![CDATA[CC-0528-03]]></id>
-              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1358</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <id><![CDATA[CC-0506-67]]></id>
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <id><![CDATA[CC-0506-65]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Greece]]></location>
@@ -2353,7 +1762,7 @@
               <state><![CDATA[Greece]]></state>
               <postalcode></postalcode>
               <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Greece - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -2367,7 +1776,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Norwegian.</li>
+<li>- Fluency in Polish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2385,121 +1794,25 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1300</min>
-                <max>1600</max>
+                <min>1045</min>
+                <max>1200</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
             </job>
             <job>
-              <title><![CDATA[Customer Support with German]]></title>
-              <id><![CDATA[CC-0506-49]]></id>
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <id><![CDATA[CC-0506-54]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
               <postalcode></postalcode>
-              <country><![CDATA[BG]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>3000</min>
-                <max>5000</max>
-                <currency>BGN</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <id><![CDATA[CC-0506-10]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1450</min>
-                <max>1750</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <id><![CDATA[CC-0506-53]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Braga]]></location>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <postalcode>4700</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2523,7 +1836,7 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
+<li>- Local de trabalho - Portugal</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <salary>
@@ -2533,11 +1846,11 @@
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-              <id><![CDATA[CC-0506-35]]></id>
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+              <id><![CDATA[CC-0506-15]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -2546,7 +1859,7 @@
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2560,7 +1873,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Polish.</li>
+<li>- Fluency in Hebrew.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2578,27 +1891,27 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1059</min>
-                <max>1260</max>
+                <min>1450</min>
+                <max>1750</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-              <id><![CDATA[CC-0506-71]]></id>
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <id><![CDATA[CC-0506-77]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
               <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+              <country><![CDATA[BG]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Communicate with customers via phone, chat, and email.</li>
@@ -2609,8 +1922,8 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
 <li>- Ability to multitask effectively;</li>
@@ -2618,319 +1931,31 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1045</min>
-                <max>1200</max>
-                <currency>EUR</currency>
+                <min>3000</min>
+                <max>5000</max>
+                <currency>BGN</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
             </job>
             <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <id><![CDATA[CC-0506-19]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Braga]]></location>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <postalcode>4700</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with French - Remote]]></title>
-              <id><![CDATA[CC-0506-62]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1045</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <id><![CDATA[CC-0506-33]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Greece]]></location>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[GR]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1300</min>
-                <max>1600</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <id><![CDATA[CC-0506-25]]></id>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <id><![CDATA[CC-0506-28]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1050</min>
-                <max>1306</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <id><![CDATA[CC-0528-01]]></id>
-              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1358</min>
-                <max>1620</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <id><![CDATA[CC-0506-20]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1200</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <id><![CDATA[CC-0506-7]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
               <country><![CDATA[PT]]></country>
               <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
@@ -2962,106 +1987,55 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1000</min>
-                <max>1150</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Bulgarian]]></title>
-              <id><![CDATA[CC-0506-23]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Bulgarian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Bulgarian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Bulgarian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
                 <min>1050</min>
                 <max>1306</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-bulgarian-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <id><![CDATA[CC-0527-74]]></id>
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <id><![CDATA[CC-0506-83]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Guimarães]]></location>
-              <city><![CDATA[Guimarães]]></city>
-              <state><![CDATA[Braga]]></state>
-              <postalcode>4800</postalcode>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
 <ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
 </ul>
-<h3>O que procuramos:</h3>
+<h3>Benefícios Adicionais:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
 </ul>
-<h3>O que oferecemos:</h3>
+<h3>Requisitos:</h3>
 <ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1160</min>
-                <max>1600</max>
+                <min>2450</min>
+                <max>2450</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
             </job>
             <job>
               <title><![CDATA[Beauty Advisor with Greek]]></title>
@@ -3115,306 +2089,16 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with Czech]]></title>
-              <id><![CDATA[CC-0506-82]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1068</min>
-                <max>1270</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <id><![CDATA[CC-0506-15]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1450</min>
-                <max>1750</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <id><![CDATA[CC-0506-12]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Porto]]></location>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <postalcode>4000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1000</min>
-                <max>1250</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Dutch]]></title>
-              <id><![CDATA[CC-0506-50]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Sofia]]></location>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[BG]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>3000</min>
-                <max>5000</max>
-                <currency>BGN</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
-              <id><![CDATA[CC-0506-30]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1400</min>
-                <max>1600</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with French - Remote]]></title>
-              <id><![CDATA[CC-0506-88]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Bulgaria]]></location>
-              <city><![CDATA[Bulgaria]]></city>
-              <state><![CDATA[Bulgaria]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[BG]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>2600</min>
-                <max>2600</max>
-                <currency>BGN</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <id><![CDATA[CC-0506-85]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <id><![CDATA[CC-0528-01]]></id>
+              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Portugal]]></location>
               <city><![CDATA[Portugal]]></city>
               <state><![CDATA[Portugal]]></state>
               <postalcode></postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -3428,7 +2112,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Turkish.</li>
+<li>- Fluency in Danish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3446,159 +2130,16 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1100</min>
-                <max>1400</max>
+                <min>1358</min>
+                <max>1620</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <id><![CDATA[CC-0506-11]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1450</min>
-                <max>1750</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <id><![CDATA[CC-0506-87]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Portugal]]></location>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <postalcode></postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1249</min>
-                <max>1249</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <id><![CDATA[CC-0506-9]]></id>
-              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
-              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Lisbon]]></location>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <postalcode>1000</postalcode>
-              <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <type>Monthly</type>
-                <min>1050</min>
-                <max>1306</max>
-                <currency>EUR</currency>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Hungarian]]></title>
-              <id><![CDATA[CC-0506-34]]></id>
+              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+              <id><![CDATA[CC-0506-13]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -3607,7 +2148,7 @@
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hungarian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3621,7 +2162,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Hungarian.</li>
+<li>- Fluency in Dutch.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3640,15 +2181,261 @@
               <salary>
                 <type>Monthly</type>
                 <min>1059</min>
+                <max>1350</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <id><![CDATA[CC-0506-4]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1150</min>
+                <max>1250</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <id><![CDATA[CC-0528-03]]></id>
+              <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1358</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <id><![CDATA[CC-0506-33]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1300</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <id><![CDATA[CC-0506-52]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
                 <max>1260</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hungarian-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
-              <id><![CDATA[CC-0506-36]]></id>
+              <title><![CDATA[Beauty Advisor with Italian]]></title>
+              <id><![CDATA[CC-0506-5]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1040</min>
+                <max>1259</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <id><![CDATA[CC-0506-38]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -3657,7 +2444,7 @@
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3671,7 +2458,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in French.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3694,57 +2481,107 @@
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Services Officer with German]]></title>
-              <id><![CDATA[CC-0506-26]]></id>
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <id><![CDATA[CC-0506-51]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
-              <location><![CDATA[Madrid]]></location>
-              <city><![CDATA[Madrid]]></city>
-              <state><![CDATA[Madrid]]></state>
-              <postalcode>28001</postalcode>
-              <country><![CDATA[ES]]></country>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in German and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
 <ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
 </ul>
-<h3>What You Need:</h3>
+<h3>Employer requirements:</h3>
 <ul>
-<li>- Fluency in German</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
 </ul>
-<h3>What We Offer:</h3>
+<h3>Benefits:</h3>
 <ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1750</min>
-                <max>2000</max>
+                <min>1059</min>
+                <max>1260</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-german-in-madrid-es]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <id><![CDATA[CC-0506-84]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1000</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
             </job>
             <job>
               <title><![CDATA[Client Support with German - Remote]]></title>
@@ -3796,8 +2633,57 @@
               <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <id><![CDATA[CC-0506-8]]></id>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <id><![CDATA[CC-0506-81]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1100</min>
+                <max>1300</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <id><![CDATA[CC-0506-10]]></id>
               <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Lisbon]]></location>
@@ -3805,8 +2691,8 @@
               <state><![CDATA[Lisbon]]></state>
               <postalcode>1000</postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3817,7 +2703,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3835,16 +2721,837 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
                 <type>Monthly</type>
-                <min>1050</min>
+                <min>1450</min>
+                <max>1750</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <id><![CDATA[CC-0506-50]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[BG]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>3000</min>
+                <max>5000</max>
+                <currency>BGN</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <id><![CDATA[CC-0506-18]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1350</min>
+                <max>1620</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <id><![CDATA[CC-0506-66]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1300</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <id><![CDATA[CC-0506-55]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <id><![CDATA[CC-0506-53]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Braga]]></location>
+              <city><![CDATA[Braga]]></city>
+              <state><![CDATA[Braga]]></state>
+              <postalcode>4700</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <id><![CDATA[CC-0527-74]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Guimarães]]></location>
+              <city><![CDATA[Guimarães]]></city>
+              <state><![CDATA[Braga]]></state>
+              <postalcode>4800</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1160</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <id><![CDATA[CC-0506-7]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1150</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <id><![CDATA[CC-0506-60]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1100</min>
+                <max>1300</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <id><![CDATA[CC-0527]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1160</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <id><![CDATA[CC-0506-89]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1295</min>
+                <max>1295</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <id><![CDATA[CC-0506-12]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1250</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <id><![CDATA[CC-0506-27]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
                 <max>1306</max>
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
             </job>
             <job>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <id><![CDATA[CC-0528-02]]></id>
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <id><![CDATA[CC-0506-42]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+              <id><![CDATA[CC-0506-39]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <id><![CDATA[CC-0506-78]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Sofia]]></location>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[BG]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>3000</min>
+                <max>5000</max>
+                <currency>BGN</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Dutch]]></title>
+              <id><![CDATA[CC-0506]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Porto]]></location>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <postalcode>4000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1050</min>
+                <max>1300</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <id><![CDATA[CC-0506-44]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1059</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <id><![CDATA[CC-0528-05]]></id>
               <listed_date><![CDATA[2025-05-28T00:00:00.000Z]]></listed_date>
               <closing_date><![CDATA[2025-06-28T00:00:00.000Z]]></closing_date>
               <location><![CDATA[Portugal]]></location>
@@ -3852,7 +3559,7 @@
               <state><![CDATA[Portugal]]></state>
               <postalcode></postalcode>
               <country><![CDATA[PT]]></country>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
 <p>Work from Home in Portugal - Equipment Provided by the company</p>
 <p>Online training</p>
 <p>Rotating hours: 40h/week</p>
@@ -3866,7 +3573,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Swedish.</li>
+<li>- Fluency in Finnish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3889,6 +3596,299 @@
                 <currency>EUR</currency>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-portugal-pt]]></url>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <id><![CDATA[CC-0506-68]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1300</min>
+                <max>1600</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <id><![CDATA[CC-0506-88]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Bulgaria]]></location>
+              <city><![CDATA[Bulgaria]]></city>
+              <state><![CDATA[Bulgaria]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[BG]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>2600</min>
+                <max>2600</max>
+                <currency>BGN</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <id><![CDATA[CC-0506-14]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1500</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <id><![CDATA[CC-0506-62]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Greece]]></location>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[GR]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1045</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <id><![CDATA[CC-0506-56]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Portugal]]></location>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <postalcode></postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1200</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <id><![CDATA[CC-0506-36]]></id>
+              <listed_date><![CDATA[2025-05-27T00:00:00.000Z]]></listed_date>
+              <closing_date><![CDATA[2025-06-26T00:00:00.000Z]]></closing_date>
+              <location><![CDATA[Lisbon]]></location>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <postalcode>1000</postalcode>
+              <country><![CDATA[PT]]></country>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <type>Monthly</type>
+                <min>1000</min>
+                <max>1260</max>
+                <currency>EUR</currency>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
             </job>
 </source>

--- a/main.py
+++ b/main.py
@@ -7,19 +7,27 @@ from Scripts.jobrapido import jobrapido
 from Scripts.jora import jora
 from Scripts.careerjet import careerjet
 from Scripts.talentcom import talentcom
+from Utils.job_fetcher import fetch_all_jobs
+import time
+
 
 def main():
+    start_time = time.time()
+    job_data_list = fetch_all_jobs()
     print("Starting RSS feed generation...")
-    feed()
-    jobatus()
-    rss()
-    jobsora()
-    jooble()
-    jobrapido()
-    jora()
-    careerjet()
-    talentcom()
+    feed(job_data_list)
+    jobatus(job_data_list)
+    rss(job_data_list)
+    jobsora(job_data_list)
+    jooble(job_data_list)
+    jobrapido(job_data_list)
+    jora(job_data_list)
+    careerjet(job_data_list)
+    talentcom(job_data_list)
     print("RSS feed generation complete.")
+    end_time = time.time()
+    print(f"Time taken: {end_time - start_time} seconds")
 
 if __name__ == "__main__":
     main()
+    

--- a/rss.xml
+++ b/rss.xml
@@ -1,327 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+    <rss version="2.0">
     <channel>
         <title>Recruityard</title>
         <link>https://www.recruityard.com</link>
         <description>Recruityard - Current Job Openings</description>  
         <item>
-            <title><![CDATA[Sales Advisor with Polish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Sales Advisor with Czech]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Services Officer with French]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Beauty Advisor with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in German.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Swedish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Danish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with English]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with Czech]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Danish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+            <title><![CDATA[Content Moderation with Norwegian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -332,108 +19,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Polish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Services Officer with English]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></link>  
-            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Italian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -483,1552 +69,10 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Interpreter with Russian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with Slovak]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Sales Advisor with French - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Sales Advisor with Hungarian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Norwegian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with French]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
-            <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with French]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Beauty Advisor with Dutch]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Finnish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Sales Advisor with Estonian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Dutch - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Services Officer with English]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Italian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with Slovenian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Russian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with French]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Finnish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with German - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Swedish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Beauty Advisor with Italian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Hebrew]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with French - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Dutch - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Ukrainian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Danish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
+            <title><![CDATA[Content Moderation with Danish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></link>  
             <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Italian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2039,7 +83,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -2089,10 +133,10 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
-            <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+            <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -2103,7 +147,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
+<li>- Fluência em Alemão;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -2116,51 +160,15 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Local de trabalho - Braga</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Beauty Advisor with Greek]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Greek.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Czech]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+            <title><![CDATA[Content Moderation with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2171,307 +179,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with Dutch]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with French - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Client Support with Turkish - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Customer Support with Italian - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-        </item>  
-        <item>
-            <title><![CDATA[Content Moderation with Dutch]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -2524,10 +232,313 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Customer Support for Social Media with Italian]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
+            <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Czech]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Finnish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Turkish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Italian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Russian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with Czech]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></link>  
             <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -2541,7 +552,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in Turkish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2551,6 +562,40 @@
 <h3>What We Offer:</h3>
 <ul>
 <li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with Italian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
@@ -2594,23 +639,59 @@
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Client Support with German - Remote]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+            <title><![CDATA[Client Services Officer with English]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></link>  
+            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German.</li>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -2619,19 +700,54 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
         </item>  
         <item>
-            <title><![CDATA[Content Moderation with German]]></title>
-            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></link>  
-            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+            <title><![CDATA[Customer Support for Social Media with English]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -2642,7 +758,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -2658,6 +774,76 @@
 <li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
         </item>  
         <item>
             <title><![CDATA[Client Support with Swedish - Remote]]></title>
@@ -2692,6 +878,1820 @@
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Beauty Advisor with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in German.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Services Officer with English]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Ukrainian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with French]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Dutch]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with Slovak]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Dutch - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Polish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hebrew.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with Czech]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Italian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></link>  
+            <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
+<ul>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+</ul>
+<h3>Benefícios Adicionais:</h3>
+<ul>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+</ul>
+<h3>Requisitos:</h3>
+<ul>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Beauty Advisor with Greek]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Greek.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Danish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Dutch - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with Polish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Beauty Advisor with Italian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with French]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with Estonian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with French - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with German - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with German - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Hebrew]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with Dutch]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Swedish]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Danish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Interpreter with Russian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with Italian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Services Officer with French]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></link>  
+            <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Content Moderation with French]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with Hungarian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with Slovenian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Beauty Advisor with Dutch]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Finnish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with Swedish - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support with French - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with German]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Client Support with French - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></link>  
+            <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+        </item>  
+        <item>
+            <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+            <link><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></link>  
+            <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
         </item>
     </channel>
 </rss>

--- a/talentcom.xml
+++ b/talentcom.xml
@@ -2,494 +2,19 @@
 <source>
     <publisher>Recruityard</publisher>
     <publisherurl>https://www.recruityard.com</publisherurl>
-    <lastBuildDate>2025-06-16T10:30:30.514654</lastBuildDate>
+    <lastBuildDate>2025-06-17T01:11:19.764412</lastBuildDate>
             <job>
-              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <title><![CDATA[Content Moderation with Norwegian]]></title>
               <company><![CDATA[Recruityard]]></company>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-52]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Czech]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-43]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with French]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-60]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1300]]></salary_max>
-                <salary_min><![CDATA[1100]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with German]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-2]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in German.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1448]]></salary_max>
-                <salary_min><![CDATA[1084]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Swedish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-68]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Swedish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with German]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-14]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1500]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-66]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with English]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-80]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1237]]></salary_max>
-                <salary_min><![CDATA[1237]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Czech]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-77]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[5000]]></salary_max>
-                <salary_min><![CDATA[3000]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Danish]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-16]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
+              <referencenumber><![CDATA[CC-0506-21]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -500,7 +25,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -519,161 +44,6 @@
               <salary>
                 <salary_max><![CDATA[1620]]></salary_max>
                 <salary_min><![CDATA[1350]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Polish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-65]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1045]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Madrid]]></city>
-              <state><![CDATA[Madrid]]></state>
-              <country><![CDATA[ES]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-57]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[2000]]></salary_max>
-                <salary_min><![CDATA[1750]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-28]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1306]]></salary_max>
-                <salary_min><![CDATA[1050]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>
@@ -734,2387 +104,17 @@
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Interpreter with Russian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-55]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Russian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovak]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-75]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovak;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[5000]]></salary_max>
-                <salary_min><![CDATA[3000]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with French - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-84]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is mandatory.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1000]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <title><![CDATA[Content Moderation with Danish]]></title>
               <company><![CDATA[Recruityard]]></company>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-42]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Norwegian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-21]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-norwegian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Norwegian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Norwegian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1350]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-44]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Lithuanian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with French]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-38]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-83]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
-              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
-<h3>Detalhes da Oferta:</h3>
-<ul>
-<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
-<li>- Remuneração ajustada à experiência profissional.</li>
-<li>- Contrato: Sem termo (permanente).</li>
-<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
-<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
-<li>- Oportunidades de progressão na carreira.</li>
-<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
-</ul>
-<h3>Benefícios Adicionais:</h3>
-<ul>
-<li>- Dois bónus anuais.</li>
-<li>- Equilíbrio entre vida pessoal e profissional.</li>
-<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
-</ul>
-<h3>Requisitos:</h3>
-<ul>
-<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
-<li>- Nível de francês B1 (obrigatório).</li>
-<li>- Motivação para trabalhar na Bélgica.</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[2450]]></salary_max>
-                <salary_min><![CDATA[2450]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Healthcare'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-6]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1100]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-86]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1358]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Dutch]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Dutch.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1300]]></salary_max>
-                <salary_min><![CDATA[1050]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-54]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-69]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with German]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-4]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1250]]></salary_max>
-                <salary_min><![CDATA[1150]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0528-04]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1358]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Sales Advisor with Estonian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-51]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
-<h3>Your responsibilities:</h3>
-<ul>
-<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
-<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
-<li>- Planning actions based on clients needs and expectations.</li>
-<li>- Researching industries and business models to better understand markets and clients.</li>
-<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
-<li>- Providing personalized recommendations based on clients needs.</li>
-<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
-<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
-<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
-<li>- Using various tools to communicate effectively and help clients succeed.</li>
-</ul>
-<h3>Employer requirements:</h3>
-<ul>
-<li>- Fluency in Estonian.</li>
-<li>- Communicative English (at least B2 level).</li>
-<li>- Previous experience in sales and/or marketing is preferred.</li>
-<li>- Strong verbal and written communication skills.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
-<li>- Opportunity to advance your career within an international and multicultural environment.</li>
-<li>- Comprehensive health insurance coverage from your first day.</li>
-<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
-<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-79]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1300]]></salary_max>
-                <salary_min><![CDATA[1100]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-39]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Greek.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Services Officer with English]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-59]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
-<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
-<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
-<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
-<li>- Contracts: registration and cancellation, premium collection.</li>
-<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
-<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
-<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
-<li>- There will be no sales or prospecting involved in this role.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in English</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Competitive monthly salary;</li>
-<li>- Permanent contract</li>
-<li>- Free healthcare insurance for you and your family</li>
-<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1300]]></salary_max>
-                <salary_min><![CDATA[1100]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Italian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-61]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1045]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Slovenian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-78]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Slovenian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[5000]]></salary_max>
-                <salary_min><![CDATA[3000]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-13]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1350]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-31]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Czech.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0527]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Porto</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Porto</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1160]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Russian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-24]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1306]]></salary_max>
-                <salary_min><![CDATA[1050]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-89]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Arabic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1295]]></salary_max>
-                <salary_min><![CDATA[1295]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with French]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-27]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1306]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-56]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
-<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
-<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
-<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
-</ul>
-<h3>Qualifications:</h3>
-<ul>
-<li>- Fluency in Ukrainian and English is required.</li>
-<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
-<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
-<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
-<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
-</ul>
-<h3>Training and Development:</h3>
-<ul>
-<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
-<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
-</ul>
-<h3>Benefits and Compensation:</h3>
-<ul>
-<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
-<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-70]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Icelandic.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Finnish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0528-05]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Finnish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1358]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-81]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1300]]></salary_max>
-                <salary_min><![CDATA[1100]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Swedish]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-18]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1350]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Italian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-5]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Italian.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1259]]></salary_max>
-                <salary_min><![CDATA[1040]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0528-03]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1358]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-67]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Norwegian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with German]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-49]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[5000]]></salary_max>
-                <salary_min><![CDATA[3000]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-10]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1750]]></salary_max>
-                <salary_min><![CDATA[1450]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-53]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Francês;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-35]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Polish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-71]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hungarian.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1045]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Braga]]></city>
-              <state><![CDATA[Braga]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-19]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Braga</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Braga</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with French - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-62]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1045]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Dutch - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-33]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Ukrainian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-25]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1306]]></salary_max>
-                <salary_min><![CDATA[1050]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Danish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0528-01]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-16]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-danish-in-lisbon-pt]]></url>
               <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Danish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1620]]></salary_max>
-                <salary_min><![CDATA[1358]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-20]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Portugal</p>
-<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
-<h3>O que irá fazer:</h3>
-<ul>
-<li>- Comunicar com clientes por telefone, chat e email;</li>
-<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
-<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
-<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
-<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
-</ul>
-<h3>O que procuramos:</h3>
-<ul>
-<li>- Fluência em Alemão;</li>
-<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
-<li>- Conhecimentos básicos de informática e competências técnicas;</li>
-<li>- Capacidade de multitarefa;</li>
-<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
-</ul>
-<h3>O que oferecemos:</h3>
-<ul>
-<li>- 40h semanais</li>
-<li>- Salário mensal competitivo;</li>
-<li>- Benefícios de saúde e vários outros descontos;</li>
-<li>- Formação completa ministrada por formadores certificados;</li>
-<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Portugal</li>
-</ul>
-<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1200]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Italian]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-7]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Danish-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3125,7 +125,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Danish; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3142,8 +142,8 @@
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
-                <salary_max><![CDATA[1150]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1350]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>
@@ -3204,17 +204,17 @@
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <title><![CDATA[Apoio ao Cliente com Alemão]]></title>
               <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Guimarães]]></city>
+              <city><![CDATA[Braga]]></city>
               <state><![CDATA[Braga]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0527-74]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
-              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
-<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+              <referencenumber><![CDATA[CC-0506-19]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-em-braga-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
 <h3>O que irá fazer:</h3>
 <ul>
 <li>- Comunicar com clientes por telefone, chat e email;</li>
@@ -3225,7 +225,7 @@
 </ul>
 <h3>O que procuramos:</h3>
 <ul>
-<li>- Fluência em Francês;</li>
+<li>- Fluência em Alemão;</li>
 <li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
 <li>- Conhecimentos básicos de informática e competências técnicas;</li>
 <li>- Capacidade de multitarefa;</li>
@@ -3238,216 +238,11 @@
 <li>- Benefícios de saúde e vários outros descontos;</li>
 <li>- Formação completa ministrada por formadores certificados;</li>
 <li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
-<li>- Local de trabalho - Guimarães</li>
+<li>- Local de trabalho - Braga</li>
 </ul>
 <p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
               <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1160]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Beauty Advisor with Greek]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-3]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
-<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
-<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
-<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
-<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
-<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
-<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
-<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
-<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluent level of written and verbal communication skills in Greek.</li>
-<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
-<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
-<li>- Aptitude for problem-solving;</li>
-<li>- Dynamism and team spirit;</li>
-<li>- Flexible and quick learner, able to adapt continuously.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1259]]></salary_max>
-                <salary_min><![CDATA[1059]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Czech]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-82]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1270]]></salary_max>
-                <salary_min><![CDATA[1068]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-15]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Hebrew.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1750]]></salary_max>
-                <salary_min><![CDATA[1450]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Porto]]></city>
-              <state><![CDATA[Porto]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-12]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in German B2</li>
-<li>- Fluent, verbal and written skills in English (C1);</li>
-<li>- Excellent communication skills;</li>
-<li>- Strong phone contact handling skills and active listening;</li>
-<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1250]]></salary_max>
+                <salary_max><![CDATA[1200]]></salary_max>
                 <salary_min><![CDATA[1000]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
@@ -3459,226 +254,17 @@
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Customer Support with Dutch]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Sofia]]></city>
-              <state><![CDATA[Sofia]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-50]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
-<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Dutch;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[5000]]></salary_max>
-                <salary_min><![CDATA[3000]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <title><![CDATA[Content Moderation with German]]></title>
               <company><![CDATA[Recruityard]]></company>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-30]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
-<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
-<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
-<li>- Provide product and tool support to enhance clients’ experience;</li>
-<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
-<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
-<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
-<li>- Provide vital product insights and feedback from our customers to engineering.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1400]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with French - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Bulgaria]]></city>
-              <state><![CDATA[Bulgaria]]></state>
-              <country><![CDATA[BG]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-88]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
-<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in French;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[2600]]></salary_max>
-                <salary_min><![CDATA[2600]]></salary_min>
-                <salary_currency><![CDATA[BGN]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Client Support with Turkish - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-85]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Portugal - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Turkish.</li>
-<li>- Proficient English communication skills.</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1400]]></salary_max>
-                <salary_min><![CDATA[1100]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-11]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+              <referencenumber><![CDATA[CC-0506-8]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -3689,109 +275,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
-<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
-<li>- Ability to objectively assess content, independent of personal beliefs.</li>
-<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
-<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
-<li>- Positive attitude and strong motivation to contribute to the team.</li>
-</ul>
-<h3>Benefits:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
-<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
-<li>- Comprehensive health insurance starting from your first day.</li>
-<li>- Performance-based monthly and quarterly bonuses.</li>
-<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1750]]></salary_max>
-                <salary_min><![CDATA[1450]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Customer Support with Italian - Remote]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Portugal]]></city>
-              <state><![CDATA[Portugal]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-87]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
-<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
-<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
-<p>Take the next step in your career by working with some of the top global brands.</p>
-<h3>What You Will Do:</h3>
-<ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
-</ul>
-<h3>What You Need:</h3>
-<ul>
-<li>- Fluency in Italian;</li>
-<li>- Proficient English communication skills;</li>
-<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
-<li>- Basic computer knowledge and technical skills;</li>
-<li>- Ability to multitask effectively;</li>
-<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
-</ul>
-<h3>What We Offer:</h3>
-<ul>
-<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
-<li>- Competitive monthly salary;</li>
-<li>- Health benefits and various other discounts;</li>
-<li>- Full training provided by certified instructors;</li>
-<li>- Opportunities for career advancement and professional development;</li>
-</ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
-              <salary>
-                <salary_max><![CDATA[1249]]></salary_max>
-                <salary_min><![CDATA[1249]]></salary_min>
-                <salary_currency><![CDATA[EUR]]></salary_currency>
-                <period><![CDATA[month]]></period>
-                <type><![CDATA[BASE_SALARY]]></type>
-              </salary>
-              <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[no]]></isremote>                            
-              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
-              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
-            </job>
-            <job>
-              <title><![CDATA[Content Moderation with Dutch]]></title>
-              <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Lisbon]]></city>
-              <state><![CDATA[Lisbon]]></state>
-              <country><![CDATA[PT]]></country>
-              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
-              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-9]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
-<h3>Key Responsibilities:</h3>
-<ul>
-<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
-<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
-<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
-<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
-<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
-</ul>
-<h3>Requirements:</h3>
-<ul>
-<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -3873,17 +357,482 @@
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-67]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Czech]]></title>
               <company><![CDATA[Recruityard]]></company>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-36]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <referencenumber><![CDATA[CC-0506-82]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-czech-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Czech and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Czech-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Czech; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1270]]></salary_max>
+                <salary_min><![CDATA[1068]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-69]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Turkish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-85]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-turkish-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Turkish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Turkish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1400]]></salary_max>
+                <salary_min><![CDATA[1100]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Italian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-61]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-italian-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1045]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Hungarian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-71]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-hungarian-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hungarian and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1045]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Russian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-24]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-russian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Russian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Russian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Russian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1306]]></salary_max>
+                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with German]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-49]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-german-in-sofia-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak German and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[5000]]></salary_max>
+                <salary_min><![CDATA[3000]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Czech]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-43]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-czech-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Turkish]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-30]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-turkish-in-lisbon-pt]]></url>
               <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
-<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Turkish?  This opportunity is for you!</p>
 <h3>What You Will Do:</h3>
 <ul>
 <li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
@@ -3897,7 +846,7 @@
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in Italian.</li>
+<li>- Fluency in Turkish.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -3914,8 +863,60 @@
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
-                <salary_max><![CDATA[1260]]></salary_max>
-                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1400]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Italian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-87]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-italian-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Portugal!</p>
+<p>We are interested in candidates who speak Italian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1249]]></salary_max>
+                <salary_min><![CDATA[1249]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>
@@ -3979,30 +980,84 @@
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Client Support with German - Remote]]></title>
+              <title><![CDATA[Client Services Officer with English]]></title>
               <company><![CDATA[Recruityard]]></company>
-              <city><![CDATA[Greece]]></city>
-              <state><![CDATA[Greece]]></state>
-              <country><![CDATA[GR]]></country>
+              <city><![CDATA[Madrid]]></city>
+              <state><![CDATA[Madrid]]></state>
+              <country><![CDATA[ES]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-32]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
-<p>Work from Home in Greece - Equipment Provided by the company</p>
-<p>Online training</p>
-<p>Rotating hours: 40h/week</p>
+              <referencenumber><![CDATA[CC-0506-57]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-madrid-es]]></url>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Madrid office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Madrid! Take the next step in your career by working with some of the top global brands.</p>
 <h3>What You Will Do:</h3>
 <ul>
-<li>- Communicate with customers via phone, chat, and email.</li>
-<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
-<li>- Maintain customer satisfaction while representing a major brand.</li>
-<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
-<li>- Work towards achieving targets set by both the client and the company.</li>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
 </ul>
 <h3>What You Need:</h3>
 <ul>
-<li>- Fluency in German.</li>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[2000]]></salary_max>
+                <salary_min><![CDATA[1750]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Czech]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-31]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-czech-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Czech?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech.</li>
 <li>- Proficient English communication skills.</li>
 <li>- Strong communication, interpersonal, and problem-solving abilities;</li>
 <li>- Basic computer knowledge and technical skills;</li>
@@ -4011,37 +1066,90 @@
 </ul>
 <h3>What We Offer:</h3>
 <ul>
-<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
 <li>- Competitive monthly salary;</li>
 <li>- Health benefits and various other discounts;</li>
 <li>- Full training provided by certified instructors;</li>
 <li>- Opportunities for career advancement and professional development;</li>
 </ul>
-<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
               <salary>
-                <salary_max><![CDATA[1600]]></salary_max>
-                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>
               </salary>
               <jobtype><![CDATA[Full time]]></jobtype>
-              <isremote><![CDATA[yes]]></isremote>                            
+              <isremote><![CDATA[no]]></isremote>                            
               <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
               <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
             </job>
             <job>
-              <title><![CDATA[Content Moderation with German]]></title>
+              <title><![CDATA[Customer Support for Social Media with English]]></title>
               <company><![CDATA[Recruityard]]></company>
               <city><![CDATA[Lisbon]]></city>
               <state><![CDATA[Lisbon]]></state>
               <country><![CDATA[PT]]></country>
               <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
               <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
-              <referencenumber><![CDATA[CC-0506-8]]></referencenumber>
-              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-lisbon-pt]]></url>
-              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
-<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+              <referencenumber><![CDATA[CC-0506-80]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-english-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in English?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1237]]></salary_max>
+                <salary_min><![CDATA[1237]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-11]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
 <h3>Key Responsibilities:</h3>
 <ul>
 <li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
@@ -4052,7 +1160,7 @@
 </ul>
 <h3>Requirements:</h3>
 <ul>
-<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
 <li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
 <li>- Ability to objectively assess content, independent of personal beliefs.</li>
 <li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
@@ -4069,8 +1177,114 @@
 </ul>
 <p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
               <salary>
-                <salary_max><![CDATA[1306]]></salary_max>
-                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_max><![CDATA[1750]]></salary_max>
+                <salary_min><![CDATA[1450]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Danish]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-86]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-danish-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Danish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Polish]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-35]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-polish-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Polish?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>
@@ -4123,6 +1337,2792 @@
               <salary>
                 <salary_max><![CDATA[1620]]></salary_max>
                 <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with German]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-2]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-german-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in German and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in German.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1448]]></salary_max>
+                <salary_min><![CDATA[1084]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with English]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-59]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-english-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>Our client  is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in English and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in English</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quaterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1300]]></salary_max>
+                <salary_min><![CDATA[1100]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Alemão - Remoto]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-20]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-alemao-remoto-em-portugal-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Alemão e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Alemão;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Ukrainian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-25]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-ukrainian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Ukrainian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Ukrainian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Ukrainian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1306]]></salary_max>
+                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-6]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1100]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Dutch]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-9]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-dutch-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Dutch-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Dutch; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1306]]></salary_max>
+                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovak]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-75]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovak-in-sofia-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovak and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovak;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[5000]]></salary_max>
+                <salary_min><![CDATA[3000]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-79]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1300]]></salary_max>
+                <salary_min><![CDATA[1100]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0528-04]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Icelandic - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-70]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-icelandic-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Icelandic and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Icelandic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Polish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-65]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-polish-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Polish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1045]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês - Remoto]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-54]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-remoto-em-portugal-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Portugal</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Portugal! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Portugal</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Hebrew]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-15]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-hebrew-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Hebrew?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Hebrew.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1750]]></salary_max>
+                <salary_min><![CDATA[1450]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Czech]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-77]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-czech-in-sofia-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Czech and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Czech;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[5000]]></salary_max>
+                <salary_min><![CDATA[3000]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-28]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1306]]></salary_max>
+                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Enfermeiros/as - Recrutamento para a Bélgica]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-83]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/enfermeiros-as-para-belgica-pt]]></url>
+              <description><![CDATA[<p>Estamos a recrutar enfermeiros/as para o nosso cliente, uma rede de hospitais e clínicas de renome na Bélgica. Procuramos profissionais qualificados e motivados para integrar equipas dinâmicas, com excelentes condições de trabalho.</p>
+<h3>Detalhes da Oferta:</h3>
+<ul>
+<li>- Salário: 2.450 euros líquidos mensais para recém-licenciados.</li>
+<li>- Remuneração ajustada à experiência profissional.</li>
+<li>- Contrato: Sem termo (permanente).</li>
+<li>- Início: Trabalho como enfermeiro/a desde o primeiro dia.</li>
+<li>- Progressão: Aumentos salariais anuais automáticos, alinhados com a taxa de inflação.</li>
+<li>- Oportunidades de progressão na carreira.</li>
+<li>- Financiamento de especializações e pós-graduações pelos hospitais.</li>
+</ul>
+<h3>Benefícios Adicionais:</h3>
+<ul>
+<li>- Dois bónus anuais.</li>
+<li>- Equilíbrio entre vida pessoal e profissional.</li>
+<li>- Apoio: Assistência completa na documentação, processos burocráticos e recolocação na Bélgica (apoio na procura de casa)</li>
+</ul>
+<h3>Requisitos:</h3>
+<ul>
+<li>- Formação em Enfermagem reconhecida na União Europeia.</li>
+<li>- Nível de francês B1 (obrigatório).</li>
+<li>- Motivação para trabalhar na Bélgica.</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[2450]]></salary_max>
+                <salary_min><![CDATA[2450]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Healthcare'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Greek]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-3]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-greek-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Greek and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Greek.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1259]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0528-01]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Dutch]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-13]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-dutch-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Dutch?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1350]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with German]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-4]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-german-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the German-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in German; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1250]]></salary_max>
+                <salary_min><![CDATA[1150]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Norwegian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0528-03]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-norwegian-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Norwegian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Norwegian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Dutch - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-33]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-dutch-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Dutch and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Polish]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-52]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-polish-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Polish.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Italian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-5]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-italian-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Italian and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Italian.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1259]]></salary_max>
+                <salary_min><![CDATA[1040]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with French]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-38]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-french-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in French?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Estonian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-51]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-estonian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Estonian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with French - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-84]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-french-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is mandatory.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1000]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-32]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with German - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-81]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-german-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1300]]></salary_max>
+                <salary_min><![CDATA[1100]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Hebrew]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-10]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-hebrew-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Hebrew and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Hebrew-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Hebrew; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1750]]></salary_max>
+                <salary_min><![CDATA[1450]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Dutch]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-50]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-dutch-in-sofia-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Dutch and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Dutch;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[5000]]></salary_max>
+                <salary_min><![CDATA[3000]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Swedish]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-18]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-swedish-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Swedish-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Swedish; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1350]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Danish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-66]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-danish-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Danish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Danish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Russian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-55]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-russian-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Russian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Russian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Braga]]></city>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-53]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-em-braga-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Braga</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Braga! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Braga</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Guimarães]]></city>
+              <state><![CDATA[Braga]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0527-74]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-braga-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Guimarães</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Guimarães! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Guimarães</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1160]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with Italian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-7]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-italian-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Italian and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the Italian-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in Italian; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1150]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Services Officer with French]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-60]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-services-officer-with-french-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>Our client is currently seeking new Client Services Officer on a permanent contract to join them and help meet the challenges of our growth.</p>
+<p>This position is based at our Lisbon office, where you will become part of a dynamic and supportive management team.</p>
+<p>In this role, you will advise and assist our clients with their inquiries via phone and email.</p>
+<p>Are you fluent in French and have strong communication skills? We have exciting job opportunities in Lisbon! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Handle customer inquiries and provide advice regarding their health insurance contracts, coverage, reimbursements, and all aspects of their contract life (subscription, amendments, cancellations, premiums, etc.).</li>
+<li>- Contracts: registration and cancellation, premium collection.</li>
+<li>- Health services: enter reimbursements, create quotes, issue coverage approvals... in accordance with internal procedures.</li>
+<li>- Client files: update and modify customer records (contract details, address, bank account information, etc.).</li>
+<li>- Contribute to customer satisfaction through the quality of your responses, the efficiency of your work, and your contribution to achieving performance indicators.</li>
+<li>- There will be no sales or prospecting involved in this role.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Competitive monthly salary;</li>
+<li>- Permanent contract</li>
+<li>- Free healthcare insurance for you and your family</li>
+<li>- Annual variable bonus if you achieve your objectives, quarterly bonus & annual bonus depending on the results of the company and medical teleconsultation.</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1300]]></salary_max>
+                <salary_min><![CDATA[1100]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Apoio ao Cliente com Francês]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0527]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/apoio-ao-cliente-com-frances-in-porto-pt]]></url>
+              <description><![CDATA[<p>Local de trabalho: Porto</p>
+<p>É fluente em Francês e tem fortes competências de comunicação? Temos oportunidades de emprego entusiasmantes em Porto! Dê o próximo passo na sua carreira ao trabalhar com algumas das principais marcas globais.</p>
+<h3>O que irá fazer:</h3>
+<ul>
+<li>- Comunicar com clientes por telefone, chat e email;</li>
+<li>- Monitorizar e resolver casos de forma eficiente, garantindo uma rápida resolução;</li>
+<li>- Assegurar a satisfação dos clientes, representando uma marca de prestígio;</li>
+<li>- Desenvolver e manter relações sólidas e profissionais com parceiros, demonstrando sempre empatia;</li>
+<li>- Trabalhar para alcançar os objetivos definidos pelo cliente e pela empresa.</li>
+</ul>
+<h3>O que procuramos:</h3>
+<ul>
+<li>- Fluência em Francês;</li>
+<li>- Fortes capacidades de comunicação, relacionamento interpessoal e resolução de problemas;</li>
+<li>- Conhecimentos básicos de informática e competências técnicas;</li>
+<li>- Capacidade de multitarefa;</li>
+<li>- Espírito de equipa e capacidade de prosperar num ambiente dinâmico e enérgico.</li>
+</ul>
+<h3>O que oferecemos:</h3>
+<ul>
+<li>- 40h semanais</li>
+<li>- Salário mensal competitivo;</li>
+<li>- Benefícios de saúde e vários outros descontos;</li>
+<li>- Formação completa ministrada por formadores certificados;</li>
+<li>- Oportunidades de progressão na carreira e desenvolvimento profissional;</li>
+<li>- Local de trabalho - Porto</li>
+</ul>
+<p>Está a dar o seu consentimento, ao abrigo do RGPD, para que os detalhes do seu CV sejam partilhados diretamente com o nosso cliente para fins de recrutamento.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1160]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Arabic]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-89]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-arabic-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Arabic?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Arabic.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1295]]></salary_max>
+                <salary_min><![CDATA[1295]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Service Agent - Banking Company with German]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-12]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-service-agent-banking-company-with-german-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in German and have strong communication skills? We have exciting job opportunities in Porto! Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German B2</li>
+<li>- Fluent, verbal and written skills in English (C1);</li>
+<li>- Excellent communication skills;</li>
+<li>- Strong phone contact handling skills and active listening;</li>
+<li>- Customer orientation and ability to adapt/respond to different types of characters.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1250]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Content Moderation with French]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-27]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/content-moderation-with-french-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>As a Content Moderator, you will be responsible for reviewing and moderating content posted on social media platforms, ensuring alignment with client guidelines and community standards. This role requires a high level of cultural and language proficiency to ensure the authenticity and appropriateness of content for the French-speaking audience.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Evaluate user-generated content to ensure adherence to platform guidelines and community standards.</li>
+<li>- Stay up-to-date on all relevant policies, procedures, and community guidelines to make accurate moderation decisions.</li>
+<li>- Track trends in content issues and provide feedback to improve moderation processes. Propose improvements based on observed trends and data.</li>
+<li>- Utilize best practices to effectively meet and exceed client KPIs and goals.</li>
+<li>- Collaborate with internal teams to share insights, suggest improvements, and contribute to the overall success of moderation projects.</li>
+</ul>
+<h3>Requirements:</h3>
+<ul>
+<li>- Fluency in French; English proficiency at a B2 level or above is also required.</li>
+<li>- Prior experience in content moderation or related fields is preferred, especially in handling high volumes of content.</li>
+<li>- Ability to objectively assess content, independent of personal beliefs.</li>
+<li>- Detail-oriented with strong analytical skills to identify content nuances.</li>
+<li>- Fast learner, adaptable to new tools and changing guidelines.</li>
+<li>- Positive attitude and strong motivation to contribute to the team.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating from abroad;</li>
+<li>- Stable employment with opportunities for career progression in a dynamic industry.</li>
+<li>- Comprehensive health insurance starting from your first day.</li>
+<li>- Performance-based monthly and quarterly bonuses.</li>
+<li>- Access to continuous training and upskilling opportunities to support your growth within the organization.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1306]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Hungarian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-42]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-hungarian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Hungarian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Greek]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-39]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-greek-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Greek?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Greek.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with Slovenian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Sofia]]></city>
+              <state><![CDATA[Sofia]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-78]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-slovenian-in-sofia-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Sofia!</p>
+<p>We are interested in candidates who speak Slovenian and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Slovenian;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Sofia for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[5000]]></salary_max>
+                <salary_min><![CDATA[3000]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Beauty Advisor with Dutch]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Porto]]></city>
+              <state><![CDATA[Porto]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/beauty-advisor-with-dutch-in-porto-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Porto!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team.</p>
+<p>We seek individuals eager to make an impact, add value, and unleash their full potential.</p>
+<p>Are you fluent in Dutch and passionate about beauty? Represent a luxury brand in Customer Care – this opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide advice, answer questions, and promote the client’s brands in every interaction;</li>
+<li>- Communicate with consumers by telephone, email, live chat, messaging and social media;</li>
+<li>- Provide advanced sales through servicing to ensure well rounded and complete beauty solution for consumers;</li>
+<li>- Place orders, resolve technical queries, and undertake associated administrative activities.</li>
+<li>- Provide first contact resolution on service inquiries, complaints and on complex consumer questions within a variety of topics;</li>
+<li>- Liaise with leadership and other teams to ensure a full resolution for the consumer.</li>
+<li>- Understand the potential risk to the business of some inquiries/complaints; Show awareness when cases need to be escalated to an I&E advisor or Team Leader (i.e. viral social media public posts)</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluent level of written and verbal communication skills in Dutch.</li>
+<li>- Good level of written and verbal communication skills in English (minimum B2).</li>
+<li>- Excellent communication skills and social intelligence – empathy, self-awareness, cultural sensitivity.</li>
+<li>- Aptitude for problem-solving;</li>
+<li>- Dynamism and team spirit;</li>
+<li>- Flexible and quick learner, able to adapt continuously.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Porto for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1300]]></salary_max>
+                <salary_min><![CDATA[1050]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Sales Advisor with Lithuanian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-44]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/sales-advisor-with-lithuanian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>As a Sales Advisor, you will identify and cultivate new business opportunities, consult with clients to understand their needs, and provide tailored solutions to drive growth while achieving sales targets.</p>
+<h3>Your responsibilities:</h3>
+<ul>
+<li>- Daily communication with new and existing clients (agencies or advertisers) via phone, chat, and email to identify sales opportunities and offer solutions tailored to their business goals.</li>
+<li>- Consultative selling to better understand clients' needs and help them achieve their objectives.</li>
+<li>- Planning actions based on clients needs and expectations.</li>
+<li>- Researching industries and business models to better understand markets and clients.</li>
+<li>- Understanding local specifics to better tailor offers for local advertisers.</li>
+<li>- Providing personalized recommendations based on clients needs.</li>
+<li>- Assisting clients in optimizing product usage, offering active support in problem-solving and performance improvement.</li>
+<li>- Expanding knowledge of advertising solutions and their impact on business performance.</li>
+<li>- Solving problems, identifying trends, and providing valuable feedback on products.</li>
+<li>- Using various tools to communicate effectively and help clients succeed.</li>
+</ul>
+<h3>Employer requirements:</h3>
+<ul>
+<li>- Fluency in Lithuanian.</li>
+<li>- Communicative English (at least B2 level).</li>
+<li>- Previous experience in sales and/or marketing is preferred.</li>
+<li>- Strong verbal and written communication skills.</li>
+</ul>
+<h3>Benefits:</h3>
+<ul>
+<li>- Comprehensive relocation support to  for candidates relocating from abroad;</li>
+<li>- Opportunity to advance your career within an international and multicultural environment.</li>
+<li>- Comprehensive health insurance coverage from your first day.</li>
+<li>- Extensive training, plus dedicated coaches to support personal and professional growth.</li>
+<li>- A clear path for growth and development within the organization, with support from a highly collaborative team.</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1059]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Finnish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-28T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-28T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0528-05]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-finnish-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Finnish and have strong communication skills? We have exciting job opportunities in Portugal! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Portugal - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Finnish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Portugal for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1620]]></salary_max>
+                <salary_min><![CDATA[1358]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with Swedish - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-68]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-swedish-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in Swedish and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Swedish.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1600]]></salary_max>
+                <salary_min><![CDATA[1300]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support with French - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Bulgaria]]></city>
+              <state><![CDATA[Bulgaria]]></state>
+              <country><![CDATA[BG]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-88]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-with-french-remote-in-bulgaria-bg]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing.</p>
+<p>Are you passionate about customer service? This is your opportunity! We are looking for talented and enthusiastic individuals to join our client in Bulgaria!</p>
+<p>We are interested in candidates who speak French and with an extensive Customer Service experience. If you want to work in a dynamic and multicultural environment, we want to meet you!</p>
+<p>Take the next step in your career by working with some of the top global brands.</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French;</li>
+<li>- Proficient English communication skills;</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Bulgaria for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[2600]]></salary_max>
+                <salary_min><![CDATA[2600]]></salary_min>
+                <salary_currency><![CDATA[BGN]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with German]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-14]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-german-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in German?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in German.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1500]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[no]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Client Support with French - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Greece]]></city>
+              <state><![CDATA[Greece]]></state>
+              <country><![CDATA[GR]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-62]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/client-support-with-french-remote-in-greece-gr]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. Are you fluent in French and have strong communication skills? We have exciting job opportunities in Greece! Take the next step in your career by working with some of the top global brands.</p>
+<p>Work from Home in Greece - Equipment Provided by the company</p>
+<p>Online training</p>
+<p>Rotating hours: 40h/week</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Communicate with customers via phone, chat, and email.</li>
+<li>- Monitor and resolve cases efficiently to ensure quick resolution.</li>
+<li>- Maintain customer satisfaction while representing a major brand.</li>
+<li>- Develop and sustain strong, professional relationships with partners, always showing empathy.</li>
+<li>- Work towards achieving targets set by both the client and the company.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in French.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Greece for candidates relocating from abroad;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1045]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Interpreter with Ukrainian - Remote]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Portugal]]></city>
+              <state><![CDATA[Portugal]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-56]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/interpreter-with-ukrainian-remote-in-portugal-pt]]></url>
+              <description><![CDATA[<p>Remote work - Equipment provided by the company. We are recruiting on behalf of our client - a worlds leading outsourcing company that provides services related to customer/technical support, content moderation, sales and marketing. As an Interpreter with Ukrainian, you will be responsible for delivering accurate and confidential interpretation services across various fields. This role demands strong linguistic skills, cultural awareness, and the ability to convey information with clarity and precision. This position may involve both remote and on-site assignments, depending on project requirements.</p>
+<h3>Key Responsibilities:</h3>
+<ul>
+<li>- Provide accurate and effective interpretation in real-time, ensuring clarity and understanding across languages.</li>
+<li>- Perform interpretation through various channels, such as phone, video, and in-person meetings, adapting to the needs of each situation.</li>
+<li>- Maintain confidentiality and sensitivity to diverse cultural nuances in all interpreted conversations.</li>
+<li>- Work independently while following ethical standards and protocols specific to each industry or client.</li>
+</ul>
+<h3>Qualifications:</h3>
+<ul>
+<li>- Fluency in Ukrainian and English is required.</li>
+<li>- Prior experience in professional interpretation, especially within sectors such as healthcare, legal, or business, is preferred.</li>
+<li>- Familiarity with remote interpretation platforms and digital communication tools.</li>
+<li>- Strong verbal communication skills, with the ability to remain neutral and impartial in all interpretations.</li>
+<li>- Availability for various shifts, including nights, weekends, and holidays as needed, based on client requirements.</li>
+</ul>
+<h3>Training and Development:</h3>
+<ul>
+<li>- Comprehensive training program covering interpretation protocols, software, and industry-specific terminology.</li>
+<li>- Ongoing professional development to enhance language skills, cultural competence, and industry knowledge.</li>
+</ul>
+<h3>Benefits and Compensation:</h3>
+<ul>
+<li>- Competitive compensation package, with options for healthcare benefits, holiday pay, and other allowances based on location and assignment type.</li>
+<li>- For remote interpreters, we provide essential technical equipment as required (e.g., headset, computer, secure connection).</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment.</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1200]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
+                <salary_currency><![CDATA[EUR]]></salary_currency>
+                <period><![CDATA[month]]></period>
+                <type><![CDATA[BASE_SALARY]]></type>
+              </salary>
+              <jobtype><![CDATA[Full time]]></jobtype>
+              <isremote><![CDATA[yes]]></isremote>                            
+              <category><![CDATA[{'@type': 'Text', 'value': 'Customer Service'}]]></category>
+              <logo><![CDATA[https://framerusercontent.com/images/FiQxGZ2DDim6z4ENGAhbwOTU8E.png?scale-down-to=60]]></logo>
+            </job>
+            <job>
+              <title><![CDATA[Customer Support for Social Media with Italian]]></title>
+              <company><![CDATA[Recruityard]]></company>
+              <city><![CDATA[Lisbon]]></city>
+              <state><![CDATA[Lisbon]]></state>
+              <country><![CDATA[PT]]></country>
+              <dateposted><![CDATA[2025-05-27T00:00:00.000Z]]></dateposted>
+              <expirationdate><![CDATA[2025-06-26T00:00:00.000Z]]></expirationdate>
+              <referencenumber><![CDATA[CC-0506-36]]></referencenumber>
+              <url><![CDATA[https://recruityard.com/find-jobs-all/customer-support-for-social-media-with-italian-in-lisbon-pt]]></url>
+              <description><![CDATA[<p>We are recruiting on behalf of our client, a leading outsourcing company providing customer and technical support, content moderation, sales, and marketing services. We have exciting job opportunities in Lisbon!</p>
+<p>Take the next step in your career by working with top global brands in a dynamic, fast-paced environment alongside a supportive team. We seek individuals eager to make an impact, add value, and unleash their full potential. Are you fluent in Italian?  This opportunity is for you!</p>
+<h3>What You Will Do:</h3>
+<ul>
+<li>- Provide support to high level clients to help them grow across multiple channels – chat, email and phone;</li>
+<li>- Support and expand the self-serve advertising base for clients in the online and digital advertising domain;</li>
+<li>- As a Customer Delight for Social Media, you’ll provide pre and post-sales support for all self-service products;</li>
+<li>- Provide product and tool support to enhance clients’ experience;</li>
+<li>- Identify and solve problems, such as technical bugs and ads’ delivery issues;</li>
+<li>- Resolve customer issues in a timely manner and pro-actively communicate to clients on progress;</li>
+<li>- Pro-actively identify areas where clients can improve usage of our solutions;</li>
+<li>- Provide vital product insights and feedback from our customers to engineering.</li>
+</ul>
+<h3>What You Need:</h3>
+<ul>
+<li>- Fluency in Italian.</li>
+<li>- Proficient English communication skills.</li>
+<li>- Strong communication, interpersonal, and problem-solving abilities;</li>
+<li>- Basic computer knowledge and technical skills;</li>
+<li>- Ability to multitask effectively;</li>
+<li>- Team-oriented with the ability to thrive in a fast-paced, energetic environment.</li>
+</ul>
+<h3>What We Offer:</h3>
+<ul>
+<li>- Comprehensive relocation support to Lisbon for candidates relocating within Europe;</li>
+<li>- Competitive monthly salary;</li>
+<li>- Health benefits and various other discounts;</li>
+<li>- Full training provided by certified instructors;</li>
+<li>- Opportunities for career advancement and professional development;</li>
+</ul>
+<p>You are giving your GDPR consent for your CV details to be shared directly with our client for the purpose of recruitment</p>]]></description>
+              <salary>
+                <salary_max><![CDATA[1260]]></salary_max>
+                <salary_min><![CDATA[1000]]></salary_min>
                 <salary_currency><![CDATA[EUR]]></salary_currency>
                 <period><![CDATA[month]]></period>
                 <type><![CDATA[BASE_SALARY]]></type>


### PR DESCRIPTION
### Note
- I have ran each script individually and collaboratively and everything is working finely after the modifications i have made, nothing is broken in the code.

### Summary
- Introduced `utils/job_fetcher.py` to centralize job scraping
- Removed redundant scraping logic from individual feed generators
- Refactored `main.py` to:
  - Fetch job data once
  - Pass shared data to all feed generators
  - Benchmark and log execution time per feed script

### Impact
- Reduced total script runtime from ~817s ➝ ~110s (~7.4x improvement)
- Reduced total codebase from **~1800 ➝ ~1200 lines** by eliminating duplication (DRY principle)
- Improved code maintainability and testability
- Foundation for future threading or async enhancements
- Refactord remaining scripts to use `job_data_list`

### Next step ideas
- Add threading for concurrent job scraping
